### PR TITLE
Show org avatars and formatted star/fork counts on Open Source page

### DIFF
--- a/open-source.md
+++ b/open-source.md
@@ -15,12 +15,17 @@ You can [sponsor my open source work via GitHub Sponsorships](https://github.com
 
 ## Featured Projects
 
-<div v-for="r in repos" :key="r.html_url" style="margin-bottom: 1.5rem; padding-bottom: 1rem; border-bottom: 1px solid var(--vp-c-divider);">
-  <h3>
-    <a :href="r.html_url" target="_blank">{{ r.full_name }}</a>
-  </h3>
-  <p>{{ r.description }}</p>
-  <p style="color: var(--vp-c-text-2); font-size: 0.9rem;">
-    ✨ {{ r.stargazers_count }} stars · 🍴 {{ r.forks_count }} forks
-  </p>
+<div v-for="r in repos" :key="r.html_url" style="display: flex; gap: 1rem; align-items: flex-start; margin-bottom: 1.5rem; padding-bottom: 1rem; border-bottom: 1px solid var(--vp-c-divider);">
+  <a :href="r.html_url" target="_blank" style="flex-shrink: 0;">
+    <img :src="`${r.owner.avatar_url}&s=80`" :alt="`${r.full_name} owner avatar`" width="48" height="48" style="border-radius: 6px; display: block;" />
+  </a>
+  <div style="flex: 1; min-width: 0;">
+    <h3 style="margin-top: 0;">
+      <a :href="r.html_url" target="_blank">{{ r.full_name }}</a>
+    </h3>
+    <p>{{ r.description }}</p>
+    <p style="color: var(--vp-c-text-2); font-size: 0.9rem;">
+      ✨ {{ r.stargazers_count.toLocaleString("en-US") }} stars · 🍴 {{ r.forks_count.toLocaleString("en-US") }} forks
+    </p>
+  </div>
 </div>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "evan@evantahler.com",
   "license": "UNLICENSED",
   "scripts": {
-    "dev": "vitepress dev",
+    "dev": "GITHUB_TOKEN=$(gh auth token 2>/dev/null) vitepress dev",
     "build": "vitepress build",
     "preview": "vitepress preview",
     "lint": "biome check .",


### PR DESCRIPTION
## Summary

- Render each featured repo's owner avatar on `/open-source` next to the project name. The avatar URL is already fetched from the GitHub API at build time in `.vitepress/data/github.data.ts` (`owner.avatar_url`) — only the page template needed updating. Avatars use `&s=80` for retina, displayed at 48×48 with the existing `.vp-doc img` border styling, and link to the repo.
- Format star and fork counts with thousands separators (`21,163` instead of `21163`) via `toLocaleString(\"en-US\")`. The locked locale keeps the pre-rendered static HTML stable.
- Bake `GITHUB_TOKEN=\$(gh auth token 2>/dev/null)` into the \`bun run dev\` script so the build-time GitHub fetch isn't subject to the anonymous 60/hr rate limit. Falls back to unauthenticated when \`gh\` isn't installed/authed (the data loader already handles an empty token).

## Test plan

- [x] \`bun run lint\` — Biome clean
- [x] \`bun run build\` — succeeds; pre-rendered \`dist/open-source.html\` shows all 9 repo avatars (ArcadeAI, airbytehq, grouparoo, actionhero ×3, elasticsearch-dump, taskrabbit, evantahler) with comma-separated counts (e.g. \`21,163 stars · 5,159 forks\`)
- [ ] Visual check on Vercel preview, light + dark mode, mobile width

🤖 Generated with [Claude Code](https://claude.com/claude-code)