### PR TITLE
Refresh CLAUDE.md for VitePress + Biome stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,122 +4,93 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-This is a personal website and blog (www.evantahler.com) built with Next.js, React, TypeScript, and React Bootstrap. The site is statically generated and deployed automatically to Vercel. It features a blog with MDX posts, tags, pagination, and a speaking engagements page.
-
-## Package Manager
-
-This project uses **bun** as the package manager and runtime. All commands should use `bun` instead of `npm` or `pnpm`.
+Personal site and blog (www.evantahler.com) built with **VitePress 1.x** and Vue 3. Static-generated and deployed automatically to Vercel on push to `main`. The package manager and runtime is **bun**.
 
 ## Common Commands
 
-### Development
-- `bun install` - Install dependencies
-- `bun run dev` - Start development server with file watching for blog posts
-- `bun run build` - Build the Next.js application for production
-- `bun start` - Start production server
+- `bun install` — install dependencies
+- `bun run dev` — start the VitePress dev server
+- `bun run build` — build static site to `.vitepress/dist`
+- `bun run preview` — preview the built site
+- `bun run lint` — Biome check (run in CI; must pass)
+- `bun run format` — Biome auto-format
 
-### Testing & Quality
-- `bun test` - Run full test suite (includes lint, build, and bun tests)
-- `bun run lint` - Check code formatting with Prettier
-- `bun run pretty` - Auto-format code with Prettier
+There is no test runner. CI (`.github/workflows/test.yml`) runs only `bun run lint` and `bun run build` on Ubuntu with the latest bun.
 
-Note: The `pretest` script automatically runs `lint`, `build`, and `postbuild` before tests.
+## Architecture
 
-### Other
-- `bun run sitemap` - Generate sitemap (runs automatically after build via `postbuild`)
+### VitePress layout — repo root is `srcDir`
 
-## Code Architecture
+`.vitepress/config.ts` sets `srcDir: "."`, so top-level Markdown files (`index.md`, `resume.md`, `contact.md`, `speaking.md`, `open-source.md`, `404.md`) are pages. `srcExclude` keeps `README.md`, `CLAUDE.md`, and `node_modules` out of the build. Output goes to `.vitepress/dist`; cache to `.vitepress/cache` (both gitignored).
 
-### Static Site Generation with Next.js
+### Two parallel post loaders — pick the right one
 
-This site uses Next.js's static generation (SSG) capabilities via `getStaticProps` and `getStaticPaths`. All pages are pre-rendered at build time.
+Blog posts live in `blog/post/*.md` as plain Markdown with gray-matter frontmatter (`title`, `date`, `tags`, `image`, `description`, `featured`, `unlisted`, `canonical`, `author`). There are two loaders that exist for different VitePress lifecycles — they must be kept in sync:
 
-### Blog System Architecture
+- `.vitepress/data/posts.data.ts` — uses `createContentLoader`. This is the runtime/SSG loader; import as `import { data as posts } from "../.vitepress/data/posts.data"` from `<script setup>` in `.md` files (used by `index.md`, `blog/index.md`, `blog/tag/[tag].md`, etc.).
+- `.vitepress/data/posts.ts` — exports `loadPosts()` which reads `blog/post/` directly with `fs` + `gray-matter`. This is for **build-time** code that runs before VitePress's content loader is available, specifically `blog/tag/[tag].paths.ts` (the dynamic-route `paths()` function).
 
-The blog is powered by MDX files stored in `pages/blog/*.mdx`. The blog infrastructure is structured as follows:
+Both loaders filter `unlisted`, sort by date desc, and produce the same `PostSummary` shape. If you change the shape in one, change the other.
 
-**Core Blog Module** (`lib/blog.ts`):
-- Exports the `Blog` namespace containing all blog-related functions
-- `getBySlug(slug)` - Reads and parses a single MDX post using gray-matter
-- `getAll({page, tag, count, featured})` - Returns paginated posts with filtering
-- `getAllTags(tag?)` - Returns tag frequency counts
-- Posts contain frontmatter metadata: `title`, `description`, `canonical`, `date`, `tags`, `image`, `featured`, `unlisted`
+`tags.data.ts` is a similar `createContentLoader` that aggregates tag counts.
 
-**Blog Routes**:
-- `/blog` - Main blog index showing recent posts (uses `pages/blog/index.tsx`)
-- `/blog/post/[slug]` - Individual blog posts (uses `pages/blog/post/[slug].tsx`)
-- `/blog/page/[page]` - Paginated blog listing
-- `/blog/tag/[tag]` - Posts filtered by tag
-- `/blog/tag/[tag]/[page]` - Paginated tag view
+### Dynamic tag routes
 
-**Blog Rendering**:
-- MDX content is rendered with `react-markdown`
-- Syntax highlighting uses `react-syntax-highlighter` with the Nord theme
-- Custom components defined in `pages/blog/post/[slug].tsx` handle images, links, and code blocks
-- Supports GitHub Flavored Markdown via `remark-gfm` and raw HTML via `rehype-raw`
+`blog/tag/[tag].md` + `blog/tag/[tag].paths.ts` generate one page per unique tag at build time. The `paths()` function uses `loadPosts()` (the fs-based loader) — not the content loader — because `paths()` runs before `createContentLoader` is ready.
 
-### Data Sources
+### Custom theme
 
-**Talks/Speaking Data** (`data/talks.ts`):
-- Array of talk objects with title, date, venue, image, description, and links
-- Used by `/speaking` page
+`.vitepress/theme/index.ts` extends `DefaultTheme` and injects `BlogPostHeader.vue` into the `doc-before` slot. The header component conditionally renders only when `route.path.startsWith("/blog/post/")` — so it appears on posts but not other pages, even though the slot is global. It also injects Vercel Analytics client-side via `enhanceApp`.
 
-### Component Structure
+### llms.txt and dev-server gotcha
 
-**Layout Components**:
-- `_app.tsx` - Root app wrapper with Header, Footer, Container, and Vercel Analytics
-- `Header.tsx` - Main navigation header
-- `Footer.tsx` - Site footer
-- `Seo.tsx` - SEO meta tags component
+`vitepress-plugin-llms` generates `llms.txt`, `llms-full.txt`, and per-page `.md` companions at **build time only**. The plugin's dev middleware rewrites every request to `.md`, which would shadow `/llms.txt` in dev. To work around this, `.vitepress/config.ts` registers a `builtAssetDevServer` Vite plugin that serves `llms.txt`, `llms-full.txt`, and `sitemap.xml` from `.vitepress/dist` during dev. **You must `bun run build` once before these URLs work in dev.** Tag pages, `blog/tags.md`, and `404.md` are excluded from llms.txt via `ignoreFiles`.
 
-**Blog Components**:
-- `BlogComponents.tsx` - Namespace with tag display and canonical link helpers
-- `BlogPostCard.tsx` - Card for displaying blog post previews
-- `BlogSidebar.tsx` - Sidebar content for blog posts
-- `FormattedDate.tsx` - Date formatting component
-- `PaginationHelper.tsx` - Pagination controls
-- `SeeAllPosts.tsx` - Link to return to blog index
+### GitHub data loader
 
-**Other Components**:
-- `ContactCards.tsx` - Contact information cards
-- `JumboImage.tsx` - Large header images
-- `SpeakingEngagementCard.tsx` - Card for displaying talks
-- `BigGlyf.tsx` - Large glyph/icon component
+`.vitepress/data/github.data.ts` fetches repo metadata from the GitHub API at build time for the open-source page. It honors `GITHUB_TOKEN` if set (recommended to avoid rate limits in CI/Vercel) and silently warns + skips on failure rather than failing the build.
 
-### Styling
+### Sitemap
 
-- Uses SASS/SCSS (`scss/site.scss`)
-- Bootstrap 5 + Bootswatch themes via `react-bootstrap`
-- Custom styles imported in `_app.tsx`
+Configured in `.vitepress/config.ts`. `transformItems` excludes `blog/tag/*` and `404`; `transformPageData` additionally sets `frontmatter.sitemap = { exclude: true }` on those pages. Keep both in sync if you add new excluded route patterns.
 
-### Configuration
+### Vercel deploy
 
-**Next.js Config** (`next.config.ts`):
-- Configures allowed image domains for GitHub avatars and profile images
+`vercel.json` installs bun via curl and runs `bun run build`; output dir is `.vitepress/dist`. Set `framework: null` so Vercel does not auto-detect.
 
-**Sitemap Config** (`next-sitemap.config.cjs`):
-- Generates sitemap automatically after build
-- Excludes tag and pagination routes from sitemap
+## Code formatting / linting
 
-**TypeScript Config** (`tsconfig.json`):
-- ES5 target with Next.js defaults
-- Strict mode disabled
+Biome (`biome.json`) is the single source of truth — Prettier and ESLint are not used. Notable config:
 
-### Testing
+- Formats `**/*.{ts,js,vue,json}` only; **`blog/post/` is excluded** so post markdown isn't reformatted.
+- Lint rules: `recommended` plus `noUnusedImports` / `noUnusedVariables` / `noTsIgnore` turned **off**.
+- Vue files have linting disabled (formatting only) via the override.
+- Style: 2-space indent, 80-char line width, double quotes, trailing commas, semicolons.
 
-- Bun's built-in test runner with jsdom environment
-- Tests use React 19's `createRoot` API
-- Test files in `__tests__/pages/` mirror the pages structure
-- Setup file: `test-setup.ts`
+## Adding a blog post
 
-### Deployment
+1. **Create the post file** at `blog/post/YYYY-MM-DD-slug.md`. The full filename (minus `.md`) becomes the URL slug — i.e. `/blog/post/2026-03-13-announcing-keryx`. The date prefix is **not** stripped; it is part of the canonical URL. Pick a filename you're willing to live with forever.
+2. **Add the image assets** under `public/images/posts/YYYY-MM-DD-slug/` (one folder per post, mirroring the filename). Reference them with absolute paths starting at `/images/posts/...` — `public/` is the VitePress static root and is stripped from URLs.
+3. **Write the frontmatter.** Required: `title`, `date` (ISO `YYYY-MM-DD`), `tags`, `image`, `description`. Optional: `featured: true` (surfaces on the home page — keep the list short), `unlisted: true` (hides from both loaders entirely), `canonical` (renders an "Originally posted at…" line in `BlogPostHeader.vue`), `author`.
+4. **Repeat the hero image in the body** as the first content line — the convention across existing posts is `![title](/images/posts/.../image.png)` right under the frontmatter, since `BlogPostHeader.vue` renders the title/date/tags but not the image.
+5. **Tags are free-form strings.** New tags automatically get a tag page generated by `blog/tag/[tag].paths.ts` — no registration needed. Reuse existing tags where possible (run `bun run dev` and visit `/blog/tags` to see the current set).
 
-The site is automatically deployed to Vercel on push to the `main` branch. The GitHub Actions workflow (`.github/workflows/test.yml`) runs tests on PRs and main branch pushes using Node.js 22.x.
+Example frontmatter (from `2026-03-13-announcing-keryx.md`):
 
-### File Watching
+```yaml
+---
+title: "Announcing Keryx: A Full-Stack TypeScript Framework for APIs and MCP Servers"
+date: "2026-03-13"
+author: Evan Tahler
+description: >-
+  After 14 years of building Actionhero, I built a new framework from scratch.
+image: /images/posts/2026-03-13-announcing-keryx/image.png
+tags:
+  - engineering
+  - typescript
+  - mcp
+featured: true
+---
+```
 
-The development server uses `next-remote-watch` to watch the `pages/blog` directory for changes to MDX files and automatically rebuild affected pages.
-
-## Code Formatting
-
-This project uses Prettier exclusively for code formatting. There are no ESLint or JSHint configurations. Prettier is enforced in CI and must pass for contributions to be accepted. Use `bun run pretty` to auto-format code.
+Markdown is plain CommonMark + GFM (no MDX, no Vue components inside posts unless you opt in via VitePress's markdown features). Code blocks use the `github-light` / `nord` Shiki themes with line numbers enabled globally. **Biome does not format `blog/post/`** — write the post however reads cleanly.


### PR DESCRIPTION
## Summary
- Rewrite the stale CLAUDE.md, which still described the pre-migration Next.js + React + Bootstrap + Prettier setup, to reflect the current VitePress 1.x + Vue 3 + Bun + Biome stack.
- Document architecture details that span multiple files: the two parallel post loaders (`posts.data.ts` runtime vs. `posts.ts` build-time for `[tag].paths.ts`), the custom theme injecting `BlogPostHeader.vue` into `doc-before`, the `builtAssetDevServer` workaround for `vitepress-plugin-llms` shadowing `/llms.txt` in dev, and the duplicated sitemap exclusions in `transformItems` + `transformPageData`.
- Add a step-by-step "Adding a blog post" section covering filename → URL slug, `public/images/posts/...` asset convention, required vs. optional frontmatter, the hero-image-in-body pattern, and that Biome does not format `blog/post/`.

## Test plan
- [x] `bun run lint` passes (no code changed; doc-only)
- [ ] Spot-check rendered Markdown in GitHub PR view

🤖 Generated with [Claude Code](https://claude.com/claude-code)