### PR TITLE
Fix blog post body disappearing on hard refresh

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -139,6 +139,7 @@ export default defineConfig({
     plugins: [
       llmstxt({
         ignoreFiles: ["blog/tag/**", "blog/tags.md", "404.md"],
+        injectLLMHint: false,
       }),
       builtAssetDevServer,
     ],


### PR DESCRIPTION
## Summary
- After the VitePress migration, blog posts at `/blog/post/<slug>` rendered correctly via SPA navigation but lost their body and outline on hard refresh / direct load.
- Root cause: `vitepress-plugin-llms@1.12.1` injects a hidden "Are you an LLM?" `<div>` into each SSG page after Vue's `createStaticVNode` count is computed, so the rendered DOM has 56 children while Vue expects 55 — triggering a hydration bail-out that wipes the body.
- Fix: set `injectLLMHint: false` on the plugin. `/llms.txt`, `/llms-full.txt`, and per-page `.md` mirrors remain intact.

## Test plan
- [x] `bun run build` succeeds and dist HTML no longer contains the hidden notice
- [x] Inner `vp-doc` child count (55) matches lean.js static count (`i("",55)`)
- [x] `bun run preview` serves `/llms.txt`, `/llms-full.txt`, and `/blog/post/<slug>.md` with 200s
- [ ] Hard-load `/blog/post/2026-03-13-curl-for-mcp` in a real browser; body and "On this page" sidebar render

🤖 Generated with [Claude Code](https://claude.com/claude-code)