### PR TITLE
Replace ```raw fences with ```text in legacy blog posts

### DIFF
--- a/blog/post/2012-01-30-nodechecker-update-now-with-ssh-and-sockets.md
+++ b/blog/post/2012-01-30-nodechecker-update-now-with-ssh-and-sockets.md
@@ -33,7 +33,7 @@ The [nodeCheker](https://github.com/evantahler/nodeChecker) project which I [spo
 
 which parses a response like:
 
-```raw
+```text
 Filesystem           1K-blocks      Used Available Use% Mounted on
 /dev/xvda1             8256952   1407440   6765640  18% /
 tmpfs                   305624         0    305624   0% /dev/shm

--- a/blog/post/2012-02-13-node-spider-now-on-actionhero.md
+++ b/blog/post/2012-02-13-node-spider-now-on-actionhero.md
@@ -23,7 +23,7 @@ Here’s a new conversation between 2 peers (and the server log it generated) as
 
 ### Client 1
 
-```raw
+```text
 > telnet localhost 5555
 
 Trying 127.0.0.1...
@@ -49,7 +49,7 @@ Connection closed by foreign host.
 
 ### Client 2
 
-```raw
+```text
 > telnet localhost 5555
 
 Trying 127.0.0.1...
@@ -74,7 +74,7 @@ Connection closed by foreign host.
 
 ### Server Log:
 
-```raw
+```text
 $ npm start
 
 > spider@2.0.0 start /Users/evantahler/PROJECTS/nodeSpider

--- a/blog/post/2012-03-30-testing-actionhero-with-blitz.md
+++ b/blog/post/2012-03-30-testing-actionhero-with-blitz.md
@@ -37,7 +37,7 @@ Still looking good, actionHero!
 
 This time when I ran the test, I decided to tail the actionHero log to see what was going on. All the requests were truly unique, but they all did appear to be coming from the same IP address (although it did change between each "rush”):
 
-```raw
+```text
 2012-03-30 21:00:52 | action @ 10.72.245.143 | params: {"key":"key_23cc985520c55346d9de7a0e9e300d0f7f07a225","value":"val_23cc985520c55346d9de7a0e9e300d0f7f07a225","action":"cacheTest","limit":100,"offset":0}
 
 2012-03-30 21:00:52 | > web request from 10.72.245.143 | responded in : 4ms

--- a/blog/post/2012-04-11-phonegap-and-push-notifications.md
+++ b/blog/post/2012-04-11-phonegap-and-push-notifications.md
@@ -63,7 +63,7 @@ What all the code above did was allow JS to access the "getToken" iOS method. Co
 
 You also need to tell the **cordova.plst** to enable the plugin by adding
 
-```raw
+```text
 <key>PushToken</key>
 <string>PushToken</string>
 ```
@@ -92,7 +92,7 @@ Just like before, I now have access to the iOs "getLastPushMessage" method. Now,
 
 You also need to tell the cordova.plst to enable the plugin by adding
 
-```raw
+```text
 <key>LastPushMessage</key>
 <string>LastPushMessage</string>
 ```

--- a/blog/post/2012-09-09-npm-run-script.md
+++ b/blog/post/2012-09-09-npm-run-script.md
@@ -17,7 +17,7 @@ Just a handy reminder that you can add "arbitrary" commands to your node NPM mod
 
 One of my favorite features of NPM is the option of installing packages either globally or locally (with local as the default). Do you want a special version of [forever](https://github.com/nodejitsu/forever) for project-\_a and not project-\_b? You can!
 
-```raw
+```text
 global: `forever start app.js`
 local: `./node_modules/.bin/forever start app.js`
 ```
@@ -28,7 +28,7 @@ This saves me so many headaches when compared to Ruby. There’s no need for som
 
 The following syntax can be used:
 
-```raw
+```text
 npm run-script #{package} #{command}
 ```
 
@@ -50,6 +50,6 @@ You all probably know that you can define a "run" and "test" actions for any pac
 
 By default, NPM will use the "run", "start", "stop", "restart" and "test" actions from the directory you are currently in. However, you can run actions from any package available to you (either local or global) with run-script. actionHero uses this to crete new projects with the command "npm run-script actionHero generate". Note the syntax:
 
-```raw
+```text
 npm run-script #{package} #{command}
 ```

--- a/blog/post/2013-02-18-authetntication-with-actionhero.md
+++ b/blog/post/2013-02-18-authetntication-with-actionhero.md
@@ -24,7 +24,7 @@ By no means is this a "full" production-ready authentication system, but this sh
 
 There are a few new folders we need to make to keep our project sane. Here’s my folder structure (with non-standard actionHero directories **bolded**):
 
-```raw
+```text
 \
 | - actions
 | - initializers

--- a/blog/post/2013-03-24-on-task-systems.md
+++ b/blog/post/2013-03-24-on-task-systems.md
@@ -32,7 +32,7 @@ For Redis based task systems (like Resque and sidekiq), Redis is a single-thread
 
 For Database-backed queues, it’s still possible to ensure an "atomic" pop, but it’s a little trickier. Lets assume we have table with the following structure:
 
-```raw
+```text
 id | created_at | data | run_at | locked_by | locked_at
 --------------------------------------------------------
 ```

--- a/blog/post/2013-04-14-forklift-moving-big-databases-around-in-ruby.md
+++ b/blog/post/2013-04-14-forklift-moving-big-databases-around-in-ruby.md
@@ -223,7 +223,7 @@ SQL Transformations can be used to [generate new tables like this](http://stacko
 
 The defaults for a new Forklift::Plan are:
 
-```raw
+```text
  1 {
  2    :project_root => Dir.pwd,
  3    :lock_with_pid? => true,
@@ -247,7 +247,7 @@ The defaults for a new Forklift::Plan are:
 
 #### Test
 
-```raw
+```text
  1 forklift.check_local_source({
  2   :name => STRING,     # A name for the test
  3   :database => STRING, # The Database to test
@@ -266,7 +266,7 @@ The defaults for a new Forklift::Plan are:
 
 #### Extract
 
-```raw
+```text
  1 forklift.import_local_database({
  2   :database => STRING,              # The Database to Extract
  3   :prefix => BOOLEAN,               # Should we prefix the names of all tables in this database when imported wight the database?
@@ -288,7 +288,7 @@ The defaults for a new Forklift::Plan are:
 
 #### Transform
 
-```raw
+```text
 1 forklift.transform_sql({
 2   :file => STRING,                 # The transformation file to run
 3   :frequency => INTEGER (seconds), # How often should we run this transformation?

--- a/blog/post/2013-06-06-actionhero-v4-1.md
+++ b/blog/post/2013-06-06-actionhero-v4-1.md
@@ -54,7 +54,7 @@ When diving into the myriad of task types, It also became clear that analyzing s
 
 An example of the new api.stats.getAll method (showing off both local and global data):
 
-```raw
+```text
 stats: {
         global: {
             tasks:tasksRun: 1006,

--- a/blog/post/2013-06-10-authentication-with-actionhero-again.md
+++ b/blog/post/2013-06-10-authentication-with-actionhero-again.md
@@ -235,7 +235,7 @@ exports.action = {
 
 ### Run it!
 
-```raw
+```text
 http://localhost:8080/api/userAdd?email=evan@evantahler.com&password=password&firstName=Evan&lastName=tahler
 http://localhost:8080/api/logIn?email=evan@evantahler.com&password=password
 http://localhost:8080/api/authenticatedAction

--- a/blog/post/2014-06-06-actionHero-v9-0-0.md
+++ b/blog/post/2014-06-06-actionHero-v9-0-0.md
@@ -97,7 +97,7 @@ api.connections.apply("abc123", "set", ["auth", true], function (err) {
 
 Two new options have been added to the config/redis.js config file to support this:
 
-```raw
+```text
 // Which channel to use on redis pub/sub for RPC communication
 channel: 'actionhero',
 // How long to wait for an RPC call before considering it a failure

--- a/blog/post/2014-07-18-elasticsearch-in-production.md
+++ b/blog/post/2014-07-18-elasticsearch-in-production.md
@@ -64,7 +64,7 @@ index.indexing.slowlog.threshold.index.trace: 500ms
 
 Enabling this showed us that in the downtime windows, we were still serving queries, but they were taking seconds to complete where normally they take milliseconds. Correlating that with the normal logs, we learned that these slower queries were blocking later queries from being parsed, and they were simply being rejected:
 
-```raw
+```text
 ...
 Caused by: org.elasticsearch.common.util.concurrent.EsRejectedExecutionException: rejected execution **(**queue capacity 1000**)** on org.elasticsearch.transport.netty.MessageChannelHandler$RequestHandler
 ...
@@ -94,7 +94,7 @@ With these options enabled, a new log file will be created which will log the oc
 
 To fix the long garbage collection time, we switched from openJDK to Oracle’s "official" Java branch. We also switched to the G1GC garbage collector from the default ConcMarkSweepGC method. To change this, you will need to modify bin/elasticsearch.in.sh, as the older options are hard-coded:
 
-```raw
+```text
 ...
 # JAVA_OPTS="$JAVA_OPTS -XX:+UseParNewGC"
 # JAVA_OPTS="$JAVA_OPTS -XX:+UseConcMarkSweepGC"

--- a/blog/post/2015-03-12-rebuilding-capistrano-with-ansible.md
+++ b/blog/post/2015-03-12-rebuilding-capistrano-with-ansible.md
@@ -39,7 +39,7 @@ I’m happy to say that TaskRabbit now deploys all of our applications via Ansib
 - We have a specific user, denoted by \`\` in these roles.
 - Our application directory structure exactly mirrors that of Capistrano (it’s a great layout), IE:
 
-```raw
+```text
 /home/{{ deploy_user }}/www/{{ application }}/
   - current (symlink to release)
   - releases
@@ -62,7 +62,7 @@ I’m happy to say that TaskRabbit now deploys all of our applications via Ansib
 
 We define inventories by RAILS_ENV (or NODE_ENV as the case may be), and then divide up each application to the sub-roles that it requires. I’ll be using the following example inventories/production file as reference:
 
-```raw
+```text
 myApp-web1.domain.com
 myApp-web2.domain.com
 myApp-worker1.domain.com
@@ -577,7 +577,7 @@ Here’s how to grab the variables you need:
 
 and our email template is:
 
-```raw
+```text
 From: {{ deploy_email_deployer_email.stdout_lines[0] }}
 Subject: Deployment: {{ application }} [ {{ cluster_env }} ]
 Content-Type: text/html

--- a/blog/post/2015-04-17-git-whereami.md
+++ b/blog/post/2015-04-17-git-whereami.md
@@ -57,7 +57,7 @@ In whichever git repository you want to use this on, copy the prepare-commit-msg
 
 Now, whenever you make a git commit, we will use whereami to source your lat/lng, and then ask Google’s geocoder what your address is, resulting in:
 
-```raw
+```text
 # Please enter the commit message for your changes. Lines starting
 # with '#' will be ignored, and an empty message aborts the commit.
 # On branch master

--- a/blog/post/2016-05-28-a-memory-leak-in-node.md
+++ b/blog/post/2016-05-28-a-memory-leak-in-node.md
@@ -17,7 +17,7 @@ We recently found & solved a memory leak in ActionHero. If you use ActionHero to
 
 This leak was discovered by the [TaskRabbit](https://www.taskrabbit.com) team when one of their micro-services kept restarting every few days. TaskRabbit uses [monit](https://mmonit.com/monit/) to run all of their applications, and when an app uses too much RAM, it will HUP the app (preforming a graceful restart) and notify the team via PagerDuty:
 
-```raw
+```text
 # managed by ansible
 
 CHECK PROCESS actionhero-{{ application }}

--- a/blog/post/2016-07-23-ansible-lets-encrypt-nginx-and-actionhero.md
+++ b/blog/post/2016-07-23-ansible-lets-encrypt-nginx-and-actionhero.md
@@ -139,7 +139,7 @@ Our NGINX.conf (and the Ansible role to manage NGINX) looks like this:
   service: name=nginx state=reloaded
 ```
 
-```raw
+```text
 # templates/production.conf.j2
 
 #user  nobody;

--- a/blog/post/2016-10-28-productionizing-flynn.md
+++ b/blog/post/2016-10-28-productionizing-flynn.md
@@ -108,7 +108,7 @@ Error writing CA certificate: Get https://dashboard.site.com/ca-cert: pinned: th
 
 The reason for this is that if you look in `~/.flynnrc`, you’ll see that your cluster has the following information saved about it:
 
-```raw
+```text
 default = "mycluster"
 [[cluster]]
   Name = "mycluster"
@@ -220,7 +220,7 @@ remote: Internal server errorfatal: unable to access 'https://git.site.com/proje
 
 This is because there is one more system setting that Flynn modifies: your `~/.gitconfig`. If you look at it you’ll see 2 entries Flynn created: A authentication block and a certificate block:
 
-```raw
+```text
 [http "https://git.site.com"]
  sslCAInfo = /Users/evan/.flynn/ca-certs/flynn-abc123.pem
 [credential "https://git.site.com"]

--- a/blog/post/2017-04-03-dont-be-a-jerk-oss.md
+++ b/blog/post/2017-04-03-dont-be-a-jerk-oss.md
@@ -20,7 +20,7 @@ Today, I ran across this license in the wild! This license has been translated i
 
 Here is the English text of the **Don’t be a Jerk** Open-Source software license, as of April 3, 2017.
 
-```raw
+```text
 Don't Be a Jerk: The Open Source Software License.
 Last Update: March 19, 2015
 

--- a/blog/post/2018-03-28-testing-node-apps-with-selenium.md
+++ b/blog/post/2018-03-28-testing-node-apps-with-selenium.md
@@ -90,7 +90,7 @@ describe("www.actionherojs.com#index", () => {
 
 Your test can now be run via the normal `jest` command*.* That’s it!
 
-```raw
+```text
 jest __tests__/integration/simple.js
  PASS  __tests__/integration/simple.js
   www.actionherojs.com#index

--- a/blog/post/2018-06-22-customizable-other-option-in-google-forms.md
+++ b/blog/post/2018-06-22-customizable-other-option-in-google-forms.md
@@ -15,7 +15,7 @@ Google Forms is a great product. It allows just about anyone (academics, compani
 
 A common use case is capturing demographic data. When asking about gender, an inclusive best practice, according to the [Human Rights Campaign](https://www.hrc.org/resources/collecting-transgender-inclusive-gender-data-in-workplace-and-other-surveys) is to provide the following options:
 
-```raw
+```text
 What is your Gender Identity?
 
 * Male

--- a/blog/post/2018-12-31-repeat-rate.md
+++ b/blog/post/2018-12-31-repeat-rate.md
@@ -27,14 +27,14 @@ _For illustrative purposes, we can simplify things and assume Voom only sells 1 
 
 **January 2018:**
 
-```raw
+```text
 Customers Acquired (2 total) \* Evan \* Christina
 Journeys Purchased this month (10 total by 2 possible customers) \* Evan: 1 \* Christina: 9
 ```
 
 **February 2018:**
 
-```raw
+```text
 Customers Acquired (1 total) \* Megan
 Journeys Purchased this month(3 total by 3 possible customers) \* Christina: 2 \* Evan: 0 \* Megan: 1
 ```

--- a/blog/post/2023-01-03-architecture-notes-2022-ctf.md
+++ b/blog/post/2023-01-03-architecture-notes-2022-ctf.md
@@ -59,7 +59,7 @@ And finally, I had the CTF solved! A novel way to prove you got to the end was t
 
 As a note, the headers for `ctf.architecturenotes.co/flag` contain cache information for Cloudflare, which was another dead-end:
 
-```raw
+```text
 report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=lCArkhBrXosMGmu8L4d1VHb0Qwlq3pZbWsBj%2BcbllnCsBgkdJLOO%2Ff2gedkaTl%2FSAwxuDQDMGjhMAranlRf7dZIa4%2FHFroO8cEfPntCmZxY50C0N7%2FsvPxTXENyO%2B17tawYenmMB1WtSZL%2FPFlq6UZtjS53qaOs%3D"}],"group":"cf-nel","max_age":604800}
 ```
 


### PR DESCRIPTION
## Summary

Silences the `The language 'raw' is not loaded, falling back to 'txt' for syntax highlighting.` warning that fired 35 times per build. ` ```raw ` was a Hexo convention meaning "no highlighting"; shiki has no `raw` language but does have `text`, which short-circuits before grammar lookup — rendered output is byte-identical.

## Test plan

- [x] `bun run build` — clean, zero `is not loaded` warnings
- [x] `bun run lint` — passes
- [x] Spot-checked rendered HTML for two affected posts; previously-`raw` blocks now render with `class="language-text"` (plain, no highlighting), matching prior behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)