### PR TITLE
Enable Vercel cleanUrls so direct loads of /blog/post/<slug> work

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,6 @@
   "framework": null,
   "installCommand": "curl -fsSL https://bun.sh/install | bash && ~/.bun/bin/bun install",
   "buildCommand": "~/.bun/bin/bun run build",
-  "outputDirectory": ".vitepress/dist"
+  "outputDirectory": ".vitepress/dist",
+  "cleanUrls": true
 }


### PR DESCRIPTION
## Summary
- Hard-refreshing or hard-linking any clean URL (e.g. `/blog/post/2025-07-23-designing-sql-tools-for-ai-agents`) returned 404 from Vercel; only `/blog/post/<slug>.html` worked.
- The Next.js → VitePress migration set `framework: null` in `vercel.json`, which disables Vercel's framework-detected rewrite for stripping `.html`. SPA navigation hid the bug because VitePress fetches asset modules directly.
- Adding `"cleanUrls": true` to `vercel.json` tells Vercel to serve `/foo.html` when `/foo` is requested, matching VitePress's `cleanUrls: true` config.

## Test plan
- [ ] After deploy, hard-load `https://www.evantahler.com/blog/post/2025-07-23-designing-sql-tools-for-ai-agents` — should 200 and render the post body.
- [ ] Hard-load `https://www.evantahler.com/blog/post/2026-03-13-curl-for-mcp` — should 200 and render.
- [ ] `/llms.txt`, `/llms-full.txt`, and `/blog/post/<slug>.md` mirrors still 200.
- [ ] Non-post pages (`/`, `/blog`, `/resume`, `/open-source`) still 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)