### PR TITLE
Restore test coverage after VitePress migration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,7 @@ jobs:
         run: bun run lint
       - name: Build
         run: bun run build
+      - name: Test
+        env:
+          SKIP_BUILD: "1"
+        run: bun run test

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .vitepress/cache
 .vitepress/dist
 public/sitemap*.xml
+coverage

--- a/.vitepress/data/posts.data.ts
+++ b/.vitepress/data/posts.data.ts
@@ -1,4 +1,4 @@
-import { createContentLoader } from "vitepress";
+import { type ContentData, createContentLoader } from "vitepress";
 
 export type PostMeta = {
   title: string;
@@ -22,39 +22,41 @@ declare const data: PostSummary[];
 
 export { data };
 
+export function transformPosts(raw: ContentData[]): PostSummary[] {
+  return raw
+    .filter((p) => !!p.frontmatter.title && !!p.frontmatter.date)
+    .filter((p) => !p.frontmatter.unlisted)
+    .map((p) => {
+      const slug =
+        p.url
+          .replace(/^\/blog\/post\//, "")
+          .replace(/\/$/, "")
+          .replace(/\.html$/, "") || "";
+      return {
+        url: p.url,
+        slug,
+        meta: {
+          title: p.frontmatter.title,
+          description: p.frontmatter.description,
+          date: p.frontmatter.date,
+          tags: p.frontmatter.tags ?? [],
+          image: p.frontmatter.image ?? "",
+          featured: p.frontmatter.featured ?? false,
+          unlisted: p.frontmatter.unlisted ?? false,
+          canonical: p.frontmatter.canonical,
+          author: p.frontmatter.author,
+        },
+      };
+    })
+    .sort(
+      (a, b) =>
+        new Date(b.meta.date).valueOf() - new Date(a.meta.date).valueOf(),
+    );
+}
+
 export default createContentLoader("blog/post/*.md", {
   includeSrc: false,
   render: false,
   excerpt: false,
-  transform(raw): PostSummary[] {
-    return raw
-      .filter((p) => !!p.frontmatter.title && !!p.frontmatter.date)
-      .filter((p) => !p.frontmatter.unlisted)
-      .map((p) => {
-        const slug =
-          p.url
-            .replace(/^\/blog\/post\//, "")
-            .replace(/\/$/, "")
-            .replace(/\.html$/, "") || "";
-        return {
-          url: p.url,
-          slug,
-          meta: {
-            title: p.frontmatter.title,
-            description: p.frontmatter.description,
-            date: p.frontmatter.date,
-            tags: p.frontmatter.tags ?? [],
-            image: p.frontmatter.image ?? "",
-            featured: p.frontmatter.featured ?? false,
-            unlisted: p.frontmatter.unlisted ?? false,
-            canonical: p.frontmatter.canonical,
-            author: p.frontmatter.author,
-          },
-        };
-      })
-      .sort(
-        (a, b) =>
-          new Date(b.meta.date).valueOf() - new Date(a.meta.date).valueOf(),
-      );
-  },
+  transform: transformPosts,
 });

--- a/.vitepress/data/tags.data.ts
+++ b/.vitepress/data/tags.data.ts
@@ -1,4 +1,4 @@
-import { createContentLoader } from "vitepress";
+import { type ContentData, createContentLoader } from "vitepress";
 
 export type TagCount = { tag: string; count: number };
 
@@ -6,16 +6,18 @@ declare const data: TagCount[];
 
 export { data };
 
+export function transformTags(raw: ContentData[]): TagCount[] {
+  const counts: Record<string, number> = {};
+  for (const p of raw) {
+    if (p.frontmatter.unlisted) continue;
+    const tags: string[] = p.frontmatter.tags ?? [];
+    for (const t of tags) counts[t] = (counts[t] || 0) + 1;
+  }
+  return Object.entries(counts)
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+}
+
 export default createContentLoader("blog/post/*.md", {
-  transform(raw): TagCount[] {
-    const counts: Record<string, number> = {};
-    for (const p of raw) {
-      if (p.frontmatter.unlisted) continue;
-      const tags: string[] = p.frontmatter.tags ?? [];
-      for (const t of tags) counts[t] = (counts[t] || 0) + 1;
-    }
-    return Object.entries(counts)
-      .map(([tag, count]) => ({ tag, count }))
-      .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
-  },
+  transform: transformTags,
 });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,10 +107,21 @@ The blog is powered by MDX files stored in `pages/blog/*.mdx`. The blog infrastr
 
 ### Testing
 
-- Bun's built-in test runner with jsdom environment
-- Tests use React 19's `createRoot` API
-- Test files in `__tests__/pages/` mirror the pages structure
-- Setup file: `test-setup.ts`
+Vitest with happy-dom; run via `bun run test`.
+
+- `bun run test:unit` — fast suite (data loaders, content integrity, Vue component); no build required
+- `bun run test` — full suite, including the rendering suite that runs `vitepress build` first via Vitest `globalSetup`
+- `bun run test:coverage` — text + html coverage report
+
+Skip-flags for the rendering suite's `globalSetup`:
+- `SKIP_BUILD=1` — skip the build step but still run rendering tests against an existing `.vitepress/dist/` (used in CI after the dedicated Build step)
+- `SKIP_RENDERING=1` — skip the build entirely (use when running only the unit/content/component suites locally)
+
+Test layout:
+- `__tests__/data/` — data loader unit tests (`posts`, `tags`, `tag-paths`, `talks`)
+- `__tests__/content/` — frontmatter integrity across every blog post + slug-uniqueness
+- `__tests__/components/` — Vue component tests (`BlogPostHeader.vue`)
+- `__tests__/rendering/` — built-HTML assertions per page type, using `node-html-parser`
 
 ### Deployment
 

--- a/__tests__/components/BlogPostHeader.test.ts
+++ b/__tests__/components/BlogPostHeader.test.ts
@@ -1,0 +1,112 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+const dataState = {
+  frontmatter: ref<Record<string, unknown>>({}),
+};
+const routeState = { path: ref("/") };
+
+vi.mock("vitepress", () => ({
+  useData: () => ({ frontmatter: dataState.frontmatter }),
+  useRoute: () => ({
+    get path() {
+      return routeState.path.value;
+    },
+  }),
+}));
+
+const BlogPostHeader = (
+  await import("../../.vitepress/theme/BlogPostHeader.vue")
+).default;
+
+function setRoute(path: string) {
+  routeState.path.value = path;
+}
+
+function setFrontmatter(fm: Record<string, unknown>) {
+  dataState.frontmatter.value = fm;
+}
+
+describe("BlogPostHeader.vue", () => {
+  it("renders nothing on non-blog routes", () => {
+    setRoute("/about");
+    setFrontmatter({ title: "About", date: "2024-01-01" });
+    const wrapper = mount(BlogPostHeader);
+    expect(wrapper.find("header.post-header").exists()).toBe(false);
+  });
+
+  it("renders title, formatted date and tags on blog post routes", () => {
+    setRoute("/blog/post/foo");
+    setFrontmatter({
+      title: "Hello World",
+      date: "2024-01-15T00:00:00.000Z",
+      tags: ["js", "node"],
+    });
+    const wrapper = mount(BlogPostHeader);
+    expect(wrapper.find("header.post-header").exists()).toBe(true);
+    expect(wrapper.find("h1").text()).toBe("Hello World");
+
+    const meta = wrapper.find(".meta").text();
+    expect(meta).toMatch(/2024/);
+    expect(meta).toMatch(/Jan/);
+
+    const tagLinks = wrapper.findAll("a.tag");
+    expect(tagLinks).toHaveLength(2);
+    expect(tagLinks[0].attributes("href")).toBe("/blog/tag/js");
+    expect(tagLinks[0].text()).toBe("js");
+    expect(tagLinks[1].attributes("href")).toBe("/blog/tag/node");
+  });
+
+  it("renders 'Originally posted at' block when canonical is set", () => {
+    setRoute("/blog/post/foo");
+    setFrontmatter({
+      title: "Hello",
+      date: "2024-01-15",
+      canonical: "https://example.com/x",
+    });
+    const wrapper = mount(BlogPostHeader);
+    const meta = wrapper.find(".meta");
+    expect(meta.text()).toMatch(/Originally posted at/);
+    const link = meta.find('a[href="https://example.com/x"]');
+    expect(link.exists()).toBe(true);
+    expect(link.attributes("target")).toBe("_blank");
+    expect(link.attributes("rel")).toBe("noopener");
+  });
+
+  it("omits 'Originally posted at' when canonical is absent", () => {
+    setRoute("/blog/post/foo");
+    setFrontmatter({ title: "Hello", date: "2024-01-15" });
+    const wrapper = mount(BlogPostHeader);
+    expect(wrapper.find(".meta").text()).not.toMatch(/Originally posted at/);
+  });
+
+  it("omits .tags container when tags are absent or empty", () => {
+    setRoute("/blog/post/foo");
+    setFrontmatter({ title: "Hello", date: "2024-01-15" });
+    let wrapper = mount(BlogPostHeader);
+    expect(wrapper.find(".tags").exists()).toBe(false);
+
+    setFrontmatter({ title: "Hello", date: "2024-01-15", tags: [] });
+    wrapper = mount(BlogPostHeader);
+    expect(wrapper.find(".tags").exists()).toBe(false);
+  });
+
+  it("formats date in en-us long format", () => {
+    setRoute("/blog/post/foo");
+    setFrontmatter({ title: "Hello", date: "2024-03-04T12:00:00.000Z" });
+    const wrapper = mount(BlogPostHeader);
+    const text = wrapper.find(".meta em").text();
+    // "Monday, Mar 4, 2024" — exact day-name depends on the date.
+    expect(text).toMatch(/^[A-Z][a-z]+, [A-Z][a-z]+ \d{1,2}, \d{4}$/);
+    expect(text).toMatch(/2024/);
+    expect(text).toMatch(/Mar/);
+  });
+
+  it("emits empty meta when date is missing", () => {
+    setRoute("/blog/post/foo");
+    setFrontmatter({ title: "Hello" });
+    const wrapper = mount(BlogPostHeader);
+    expect(wrapper.find(".meta em").text().trim()).toBe("");
+  });
+});

--- a/__tests__/content/frontmatter.test.ts
+++ b/__tests__/content/frontmatter.test.ts
@@ -1,0 +1,56 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import matter from "gray-matter";
+import { describe, expect, it } from "vitest";
+
+const POST_DIR = join(process.cwd(), "blog", "post");
+const files = readdirSync(POST_DIR).filter((f) => f.endsWith(".md"));
+
+describe("blog post frontmatter", () => {
+  it("found at least one post", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it.each(files)("%s has valid frontmatter", (file) => {
+    const raw = readFileSync(join(POST_DIR, file), "utf8");
+    const { data } = matter(raw);
+
+    expect(typeof data.title).toBe("string");
+    expect((data.title as string).trim()).not.toBe("");
+
+    expect(data.date).toBeDefined();
+    const date = new Date(data.date as string | number | Date);
+    expect(Number.isNaN(date.valueOf())).toBe(false);
+    expect(date.getFullYear()).toBeGreaterThan(2000);
+
+    if (data.tags !== undefined) {
+      expect(Array.isArray(data.tags)).toBe(true);
+      for (const tag of data.tags as unknown[]) {
+        expect(typeof tag).toBe("string");
+        expect((tag as string).trim()).not.toBe("");
+      }
+    }
+
+    if (data.canonical !== undefined) {
+      expect(typeof data.canonical).toBe("string");
+      expect(data.canonical as string).toMatch(/^https?:\/\//);
+    }
+
+    if (data.image !== undefined) {
+      expect(typeof data.image).toBe("string");
+      expect(data.image as string).toMatch(/^(\/|https?:\/\/)/);
+    }
+
+    if (data.featured !== undefined) {
+      expect(typeof data.featured).toBe("boolean");
+    }
+
+    if (data.unlisted !== undefined) {
+      expect(typeof data.unlisted).toBe("boolean");
+    }
+
+    if (data.description !== undefined) {
+      expect(typeof data.description).toBe("string");
+    }
+  });
+});

--- a/__tests__/content/posts-no-duplicate-slugs.test.ts
+++ b/__tests__/content/posts-no-duplicate-slugs.test.ts
@@ -1,0 +1,15 @@
+import { readdirSync } from "node:fs";
+import { basename, extname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("blog post slugs", () => {
+  it("no two posts share the same slug", () => {
+    const dir = join(process.cwd(), "blog", "post");
+    const files = readdirSync(dir).filter((f) => f.endsWith(".md"));
+    const slugs = files.map((f) => basename(f, extname(f)));
+    const seen = new Map<string, number>();
+    for (const slug of slugs) seen.set(slug, (seen.get(slug) ?? 0) + 1);
+    const dupes = [...seen.entries()].filter(([, n]) => n > 1);
+    expect(dupes).toEqual([]);
+  });
+});

--- a/__tests__/data/posts-data.test.ts
+++ b/__tests__/data/posts-data.test.ts
@@ -1,0 +1,108 @@
+import type { ContentData } from "vitepress";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("vitepress", () => ({
+  createContentLoader: () => ({}),
+}));
+
+const { transformPosts } = await import("../../.vitepress/data/posts.data");
+
+function fixture(
+  url: string,
+  frontmatter: Record<string, unknown>,
+): ContentData {
+  return {
+    url,
+    frontmatter,
+    src: undefined,
+    html: undefined,
+    excerpt: undefined,
+  };
+}
+
+describe("transformPosts", () => {
+  it("filters posts missing title or date", () => {
+    const out = transformPosts([
+      fixture("/blog/post/no-title", { date: "2024-01-01" }),
+      fixture("/blog/post/no-date", { title: "x" }),
+      fixture("/blog/post/ok", { title: "Ok", date: "2024-01-01" }),
+    ]);
+    expect(out.map((p) => p.slug)).toEqual(["ok"]);
+  });
+
+  it("filters unlisted posts", () => {
+    const out = transformPosts([
+      fixture("/blog/post/visible", { title: "v", date: "2024-01-01" }),
+      fixture("/blog/post/hidden", {
+        title: "h",
+        date: "2024-02-01",
+        unlisted: true,
+      }),
+    ]);
+    expect(out.map((p) => p.slug)).toEqual(["visible"]);
+  });
+
+  it("sorts newest-first by date", () => {
+    const out = transformPosts([
+      fixture("/blog/post/old", { title: "Old", date: "2020-01-01" }),
+      fixture("/blog/post/new", { title: "New", date: "2025-01-01" }),
+      fixture("/blog/post/mid", { title: "Mid", date: "2023-06-01" }),
+    ]);
+    expect(out.map((p) => p.slug)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("strips /blog/post/ prefix, trailing slash, and .html suffix from slug", () => {
+    const cases: Array<[string, string]> = [
+      ["/blog/post/foo", "foo"],
+      ["/blog/post/foo/", "foo"],
+      ["/blog/post/foo.html", "foo"],
+      ["/blog/post/nested-thing", "nested-thing"],
+    ];
+    for (const [url, expected] of cases) {
+      const [out] = transformPosts([
+        fixture(url, { title: "t", date: "2024-01-01" }),
+      ]);
+      expect(out.slug).toBe(expected);
+      expect(out.url).toBe(url);
+    }
+  });
+
+  it("applies meta defaults for missing optional fields", () => {
+    const [out] = transformPosts([
+      fixture("/blog/post/min", { title: "Min", date: "2024-01-01" }),
+    ]);
+    expect(out.meta).toMatchObject({
+      tags: [],
+      image: "",
+      featured: false,
+      unlisted: false,
+    });
+    expect(out.meta.canonical).toBeUndefined();
+    expect(out.meta.author).toBeUndefined();
+    expect(out.meta.description).toBeUndefined();
+  });
+
+  it("preserves frontmatter values when present", () => {
+    const [out] = transformPosts([
+      fixture("/blog/post/full", {
+        title: "Full",
+        date: "2024-01-01",
+        description: "d",
+        tags: ["a", "b"],
+        image: "/i.png",
+        featured: true,
+        canonical: "https://example.com/x",
+        author: "Evan",
+      }),
+    ]);
+    expect(out.meta).toMatchObject({
+      title: "Full",
+      description: "d",
+      tags: ["a", "b"],
+      image: "/i.png",
+      featured: true,
+      canonical: "https://example.com/x",
+      author: "Evan",
+    });
+  });
+});

--- a/__tests__/data/posts-loader.test.ts
+++ b/__tests__/data/posts-loader.test.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+let originalCwd: string;
+let tmpRoot: string;
+
+beforeAll(() => {
+  originalCwd = process.cwd();
+  tmpRoot = mkdtempSync(join(tmpdir(), "posts-loader-"));
+  const postDir = join(tmpRoot, "blog", "post");
+  mkdirSync(postDir, { recursive: true });
+
+  writeFileSync(
+    join(postDir, "alpha.md"),
+    [
+      "---",
+      "title: Alpha",
+      "date: 2024-01-01",
+      "tags: [a, b]",
+      "image: /img/a.png",
+      "featured: true",
+      "description: alpha desc",
+      "canonical: https://example.com/a",
+      "author: Evan",
+      "---",
+      "body",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(postDir, "beta.md"),
+    ["---", "title: Beta", "date: 2024-06-01", "---", "body"].join("\n"),
+  );
+  writeFileSync(
+    join(postDir, "gamma.md"),
+    [
+      "---",
+      "title: Gamma",
+      "date: 2025-01-01",
+      "unlisted: true",
+      "---",
+      "body",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(postDir, "no-title.md"),
+    ["---", "date: 2024-01-01", "---", "body"].join("\n"),
+  );
+  writeFileSync(
+    join(postDir, "no-date.md"),
+    ["---", "title: NoDate", "---", "body"].join("\n"),
+  );
+  writeFileSync(join(postDir, "ignored.txt"), "not markdown");
+
+  process.chdir(tmpRoot);
+});
+
+afterAll(() => {
+  process.chdir(originalCwd);
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("loadPosts", () => {
+  it("filters unlisted, missing-title, missing-date and sorts newest-first", async () => {
+    const { loadPosts } = await import("../../.vitepress/data/posts");
+    const posts = loadPosts();
+    expect(posts.map((p) => p.slug)).toEqual(["beta", "alpha"]);
+  });
+
+  it("derives url from slug and applies meta defaults", async () => {
+    const { loadPosts } = await import("../../.vitepress/data/posts");
+    const posts = loadPosts();
+
+    const alpha = posts.find((p) => p.slug === "alpha");
+    expect(alpha).toBeDefined();
+    if (!alpha) return;
+    expect(alpha.url).toBe("/blog/post/alpha");
+    expect(alpha.meta.tags).toEqual(["a", "b"]);
+    expect(alpha.meta.image).toBe("/img/a.png");
+    expect(alpha.meta.featured).toBe(true);
+    expect(alpha.meta.canonical).toBe("https://example.com/a");
+    expect(alpha.meta.author).toBe("Evan");
+
+    const beta = posts.find((p) => p.slug === "beta");
+    expect(beta).toBeDefined();
+    if (!beta) return;
+    expect(beta.meta.tags).toEqual([]);
+    expect(beta.meta.image).toBe("");
+    expect(beta.meta.featured).toBe(false);
+    expect(beta.meta.canonical).toBeUndefined();
+  });
+});

--- a/__tests__/data/posts-parity.test.ts
+++ b/__tests__/data/posts-parity.test.ts
@@ -1,0 +1,55 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import matter from "gray-matter";
+import type { ContentData } from "vitepress";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("vitepress", () => ({
+  createContentLoader: () => ({}),
+}));
+
+const { transformPosts } = await import("../../.vitepress/data/posts.data");
+const { loadPosts } = await import("../../.vitepress/data/posts");
+
+const POST_DIR = join(process.cwd(), "blog", "post");
+
+function loadViaTransform() {
+  const files = readdirSync(POST_DIR).filter((f) => f.endsWith(".md"));
+  const raw: ContentData[] = files.map((file) => {
+    const text = readFileSync(join(POST_DIR, file), "utf8");
+    const { data } = matter(text);
+    const slug = file.replace(/\.md$/, "");
+    return {
+      url: `/blog/post/${slug}`,
+      frontmatter: data,
+      src: undefined,
+      html: undefined,
+      excerpt: undefined,
+    };
+  });
+  return transformPosts(raw);
+}
+
+describe("posts loader / transform parity", () => {
+  it("loadPosts() and transformPosts() produce the same posts in the same order", () => {
+    const fromLoader = loadPosts();
+    const fromTransform = loadViaTransform();
+
+    expect(fromLoader.length).toBe(fromTransform.length);
+    expect(fromLoader.map((p) => p.slug)).toEqual(
+      fromTransform.map((p) => p.slug),
+    );
+
+    for (let i = 0; i < fromLoader.length; i++) {
+      const a = fromLoader[i];
+      const b = fromTransform[i];
+      expect(a.url).toBe(b.url);
+      expect(a.meta.title).toBe(b.meta.title);
+      expect(String(a.meta.date)).toBe(String(b.meta.date));
+      expect(a.meta.tags).toEqual(b.meta.tags);
+      expect(a.meta.featured).toBe(b.meta.featured);
+      expect(a.meta.unlisted).toBe(b.meta.unlisted);
+      expect(a.meta.canonical).toBe(b.meta.canonical);
+    }
+  });
+});

--- a/__tests__/data/tag-paths.test.ts
+++ b/__tests__/data/tag-paths.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../.vitepress/data/posts", () => ({
+  loadPosts: () => [
+    {
+      url: "/blog/post/a",
+      slug: "a",
+      meta: {
+        title: "A",
+        date: "2024-01-01",
+        tags: ["zebra", "apple"],
+        image: "",
+      },
+    },
+    {
+      url: "/blog/post/b",
+      slug: "b",
+      meta: {
+        title: "B",
+        date: "2024-02-01",
+        tags: ["mango", "apple"],
+        image: "",
+      },
+    },
+    {
+      url: "/blog/post/c",
+      slug: "c",
+      meta: { title: "C", date: "2024-03-01", tags: [], image: "" },
+    },
+  ],
+}));
+
+describe("[tag].paths", () => {
+  it("emits one path per unique tag, alphabetically sorted", async () => {
+    const mod = await import("../../blog/tag/[tag].paths");
+    const result = mod.default.paths();
+    expect(result).toEqual([
+      { params: { tag: "apple" } },
+      { params: { tag: "mango" } },
+      { params: { tag: "zebra" } },
+    ]);
+  });
+});

--- a/__tests__/data/tags.test.ts
+++ b/__tests__/data/tags.test.ts
@@ -1,0 +1,61 @@
+import type { ContentData } from "vitepress";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("vitepress", () => ({
+  createContentLoader: () => ({}),
+}));
+
+const { transformTags } = await import("../../.vitepress/data/tags.data");
+
+function fixture(frontmatter: Record<string, unknown>): ContentData {
+  return {
+    url: "/blog/post/x",
+    frontmatter,
+    src: undefined,
+    html: undefined,
+    excerpt: undefined,
+  };
+}
+
+describe("transformTags", () => {
+  it("returns [] for empty input", () => {
+    expect(transformTags([])).toEqual([]);
+  });
+
+  it("counts tag occurrences across posts", () => {
+    const out = transformTags([
+      fixture({ tags: ["js", "node"] }),
+      fixture({ tags: ["js", "redis"] }),
+      fixture({ tags: ["js"] }),
+    ]);
+    const map = Object.fromEntries(out.map((t) => [t.tag, t.count]));
+    expect(map).toEqual({ js: 3, node: 1, redis: 1 });
+  });
+
+  it("excludes unlisted posts from tag counts", () => {
+    const out = transformTags([
+      fixture({ tags: ["a"] }),
+      fixture({ tags: ["a", "b"], unlisted: true }),
+    ]);
+    const map = Object.fromEntries(out.map((t) => [t.tag, t.count]));
+    expect(map).toEqual({ a: 1 });
+  });
+
+  it("tolerates posts with no tags field", () => {
+    const out = transformTags([fixture({}), fixture({ tags: ["a"] })]);
+    expect(out).toEqual([{ tag: "a", count: 1 }]);
+  });
+
+  it("sorts by count desc, then tag asc as tiebreaker", () => {
+    const out = transformTags([
+      fixture({ tags: ["zebra", "apple", "mango"] }),
+      fixture({ tags: ["apple", "mango"] }),
+      fixture({ tags: ["mango"] }),
+    ]);
+    expect(out).toEqual([
+      { tag: "mango", count: 3 },
+      { tag: "apple", count: 2 },
+      { tag: "zebra", count: 1 },
+    ]);
+  });
+});

--- a/__tests__/data/talks.test.ts
+++ b/__tests__/data/talks.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { talks } from "../../data/talks";
+
+describe("talks data", () => {
+  it("has at least one talk", () => {
+    expect(talks.length).toBeGreaterThan(0);
+  });
+
+  it.each(talks)("'$title' has all required fields", (talk) => {
+    expect(talk.title.trim()).not.toBe("");
+    expect(talk.date.trim()).not.toBe("");
+    expect(talk.where.trim()).not.toBe("");
+    expect(talk.description.trim()).not.toBe("");
+    expect(talk.image).toMatch(/^(\/|https?:\/\/)/);
+  });
+
+  it.each(talks)("'$title' has valid links", (talk) => {
+    expect(Array.isArray(talk.links)).toBe(true);
+    for (const link of talk.links) {
+      expect(link.title.trim()).not.toBe("");
+      expect(link.url).toMatch(/^https?:\/\//);
+    }
+  });
+});

--- a/__tests__/rendering/404.test.ts
+++ b/__tests__/rendering/404.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { cleanText, loadPage } from "./_helpers";
+
+describe("404 page (/404)", () => {
+  const page = loadPage("/404");
+
+  it("emits a 'Page not found' title (server-rendered shell)", () => {
+    const title = cleanText(page.querySelector("title")?.textContent);
+    expect(title.toLowerCase()).toContain("not found");
+  });
+
+  it("includes the site description meta tag", () => {
+    const desc = page
+      .querySelector('meta[name="description"]')
+      ?.getAttribute("content");
+    expect((desc ?? "").length).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/rendering/_helpers.ts
+++ b/__tests__/rendering/_helpers.ts
@@ -1,0 +1,36 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { type HTMLElement, parse } from "node-html-parser";
+
+const DIST = join(process.cwd(), ".vitepress", "dist");
+
+export function distPath(...segments: string[]): string {
+  return join(DIST, ...segments);
+}
+
+export function loadPage(route: string): HTMLElement {
+  // Map a logical route ("/", "/blog/", "/blog/post/foo") to dist HTML.
+  // VitePress emits flat .html files, not directory/index.html nests.
+  let file: string;
+  if (route === "/" || route === "") {
+    file = distPath("index.html");
+  } else {
+    const trimmed = route.replace(/^\/+|\/+$/g, "");
+    file = distPath(`${trimmed}.html`);
+    if (!existsSync(file)) {
+      file = distPath(trimmed, "index.html");
+    }
+  }
+  if (!existsSync(file)) {
+    throw new Error(
+      `Built page not found for route ${route} (looked at ${file})`,
+    );
+  }
+  return parse(readFileSync(file, "utf8"));
+}
+
+// VitePress appends a zero-width-space to header anchors. Strip it for
+// readable assertions.
+export function cleanText(s: string | undefined | null): string {
+  return (s ?? "").replace(/​/g, "").replace(/\s+/g, " ").trim();
+}

--- a/__tests__/rendering/blog-index.test.ts
+++ b/__tests__/rendering/blog-index.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { cleanText, loadPage } from "./_helpers";
+
+vi.mock("vitepress", () => ({
+  createContentLoader: () => ({}),
+}));
+
+const { loadPosts } = await import("../../.vitepress/data/posts");
+
+describe("blog index (/blog/)", () => {
+  const page = loadPage("/blog/");
+  const posts = loadPosts();
+
+  it("renders an h1", () => {
+    expect(page.querySelector("h1")).toBeTruthy();
+  });
+
+  it("renders year-grouping h2 headings (4-digit years)", () => {
+    const yearH2s = page
+      .querySelectorAll(".vp-doc h2")
+      .map((h) => cleanText(h.textContent))
+      .filter((t) => /^\d{4}$/.test(t));
+    expect(yearH2s.length).toBeGreaterThan(0);
+  });
+
+  it("links to every non-unlisted post", () => {
+    const links = page.querySelectorAll('a[href^="/blog/post/"]');
+    const hrefs = new Set(
+      links.map((l) => l.getAttribute("href") ?? "").filter(Boolean),
+    );
+    for (const post of posts) {
+      expect(
+        hrefs.has(post.url) || hrefs.has(`${post.url}.html`),
+        `Expected blog index to link to ${post.url}`,
+      ).toBe(true);
+    }
+  });
+
+  it("renders post images for posts that declare one", () => {
+    const imgs = page.querySelectorAll(".vp-doc img");
+    expect(imgs.length).toBeGreaterThan(0);
+    for (const img of imgs) {
+      expect((img.getAttribute("src") ?? "").length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/__tests__/rendering/blog-post.test.ts
+++ b/__tests__/rendering/blog-post.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { cleanText, loadPage } from "./_helpers";
+
+vi.mock("vitepress", () => ({
+  createContentLoader: () => ({}),
+}));
+
+const { loadPosts } = await import("../../.vitepress/data/posts");
+
+const POSTS = loadPosts();
+// Pick the most-recent post that has both tags and an image so we can
+// assert against the full BlogPostHeader + content surface.
+const SAMPLE = POSTS.find(
+  (p) => (p.meta.tags?.length ?? 0) > 0 && p.meta.image,
+);
+
+describe("blog post (/blog/post/<slug>)", () => {
+  if (!SAMPLE) {
+    it.skip("no suitable sample post found", () => {});
+    return;
+  }
+
+  const page = loadPage(SAMPLE.url);
+
+  it("renders the BlogPostHeader with the post title", () => {
+    expect(page.querySelector(".post-header")).toBeTruthy();
+    expect(cleanText(page.querySelector(".post-header h1")?.textContent)).toBe(
+      SAMPLE.meta.title,
+    );
+  });
+
+  it("renders a formatted date in the meta block", () => {
+    const meta = cleanText(
+      page.querySelector(".post-header .meta")?.textContent,
+    );
+    const year = String(new Date(SAMPLE.meta.date).getFullYear());
+    expect(meta).toContain(year);
+  });
+
+  it("renders a tag pill linking to /blog/tag/<tag> for every tag", () => {
+    const renderedTags = page
+      .querySelectorAll(".post-header a.tag")
+      .map((a) => ({
+        text: cleanText(a.textContent),
+        href: a.getAttribute("href") ?? "",
+      }));
+    for (const tag of SAMPLE.meta.tags) {
+      const match = renderedTags.find((r) => r.text === tag);
+      expect(match, `Expected rendered tag pill for "${tag}"`).toBeDefined();
+      expect(match?.href).toBe(`/blog/tag/${tag}`);
+    }
+  });
+
+  it("renders body content with at least one heading and paragraph", () => {
+    const headings = page.querySelectorAll(".vp-doc h2, .vp-doc h3");
+    const paragraphs = page.querySelectorAll(".vp-doc p");
+    expect(headings.length).toBeGreaterThan(0);
+    expect(paragraphs.length).toBeGreaterThan(0);
+  });
+
+  it("renders at least one image", () => {
+    const imgs = page.querySelectorAll(".vp-doc img");
+    expect(imgs.length).toBeGreaterThan(0);
+    expect(imgs[0].getAttribute("src")).toBeTruthy();
+  });
+
+  it("emits a <title> and meta description that reflect the post", () => {
+    expect(cleanText(page.querySelector("title")?.textContent)).toContain(
+      SAMPLE.meta.title,
+    );
+    if (SAMPLE.meta.description) {
+      expect(
+        page.querySelector('meta[name="description"]')?.getAttribute("content"),
+      ).toBe(SAMPLE.meta.description);
+    }
+  });
+});
+
+describe("blog post with canonical link", () => {
+  const sampleWithCanonical = POSTS.find((p) => p.meta.canonical);
+
+  if (!sampleWithCanonical) {
+    it.skip("no post with canonical found", () => {});
+    return;
+  }
+
+  it("renders 'Originally posted at' with the canonical URL", () => {
+    const page = loadPage(sampleWithCanonical.url);
+    const meta = page.querySelector(".post-header .meta");
+    expect(cleanText(meta?.textContent)).toContain("Originally posted at");
+    const link = meta?.querySelector(
+      `a[href="${sampleWithCanonical.meta.canonical}"]`,
+    );
+    expect(link, "canonical link should appear in meta").toBeTruthy();
+    expect(link?.getAttribute("target")).toBe("_blank");
+  });
+});

--- a/__tests__/rendering/blog-tag.test.ts
+++ b/__tests__/rendering/blog-tag.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadPage } from "./_helpers";
+
+vi.mock("vitepress", () => ({
+  createContentLoader: () => ({}),
+}));
+
+const { loadPosts } = await import("../../.vitepress/data/posts");
+
+const POSTS = loadPosts();
+
+const tagCounts: Record<string, number> = {};
+for (const p of POSTS)
+  for (const t of p.meta.tags) tagCounts[t] = (tagCounts[t] ?? 0) + 1;
+const SAMPLE_TAG = Object.entries(tagCounts).sort(
+  (a, b) => b[1] - a[1],
+)[0]?.[0];
+
+describe("blog tag page (/blog/tag/<tag>)", () => {
+  if (!SAMPLE_TAG) {
+    it.skip("no tags found", () => {});
+    return;
+  }
+
+  const page = loadPage(`/blog/tag/${SAMPLE_TAG}`);
+
+  it("renders an h1 mentioning the tag", () => {
+    const h1Text = page.querySelector("h1")?.textContent ?? "";
+    expect(h1Text).toContain(SAMPLE_TAG);
+  });
+
+  it("links to every post that has this tag (and no others)", () => {
+    const expectedSlugs = new Set(
+      POSTS.filter((p) => p.meta.tags.includes(SAMPLE_TAG)).map((p) => p.slug),
+    );
+    const renderedHrefs = new Set(
+      page
+        .querySelectorAll('.vp-doc a[href^="/blog/post/"]')
+        .map((a) => a.getAttribute("href") ?? ""),
+    );
+    for (const slug of expectedSlugs) {
+      expect(
+        renderedHrefs.has(`/blog/post/${slug}`) ||
+          renderedHrefs.has(`/blog/post/${slug}.html`),
+        `Expected /blog/post/${slug} on tag page for "${SAMPLE_TAG}"`,
+      ).toBe(true);
+    }
+    expect(renderedHrefs.size).toBe(expectedSlugs.size);
+  });
+});

--- a/__tests__/rendering/blog-tags-index.test.ts
+++ b/__tests__/rendering/blog-tags-index.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadPage } from "./_helpers";
+
+vi.mock("vitepress", () => ({
+  createContentLoader: () => ({}),
+}));
+
+const { loadPosts } = await import("../../.vitepress/data/posts");
+
+const POSTS = loadPosts();
+const allTags = new Set<string>();
+for (const p of POSTS) for (const t of p.meta.tags) allTags.add(t);
+
+describe("tags index (/blog/tags)", () => {
+  const page = loadPage("/blog/tags");
+
+  it("links to every distinct tag's tag page", () => {
+    const renderedHrefs = new Set(
+      page
+        .querySelectorAll('a[href^="/blog/tag/"]')
+        .map((a) => a.getAttribute("href") ?? ""),
+    );
+    for (const tag of allTags) {
+      expect(
+        renderedHrefs.has(`/blog/tag/${tag}`) ||
+          renderedHrefs.has(`/blog/tag/${tag}.html`),
+        `Expected tag link for "${tag}"`,
+      ).toBe(true);
+    }
+  });
+});

--- a/__tests__/rendering/contact.test.ts
+++ b/__tests__/rendering/contact.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { cleanText, loadPage } from "./_helpers";
+
+describe("contact page (/contact)", () => {
+  const page = loadPage("/contact");
+
+  it("renders an h1", () => {
+    expect(cleanText(page.querySelector("h1")?.textContent)).not.toBe("");
+  });
+
+  it("contains the 'Delicious Hat' phrase (preserves prior smoke-test intent)", () => {
+    const text = page.querySelector(".vp-doc")?.textContent ?? "";
+    expect(text).toMatch(/Delicious Hat/);
+  });
+
+  it("renders at least one external contact link", () => {
+    const externalLinks = page.querySelectorAll(
+      '.vp-doc a[href^="http"], .vp-doc a[href^="mailto:"]',
+    );
+    expect(externalLinks.length).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/rendering/home.test.ts
+++ b/__tests__/rendering/home.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { cleanText, loadPage } from "./_helpers";
+
+describe("home page (/)", () => {
+  const page = loadPage("/");
+
+  it("has a title with the site name", () => {
+    expect(cleanText(page.querySelector("title")?.textContent)).toContain(
+      "Evan Tahler",
+    );
+  });
+
+  it("renders an h1 mentioning Evan", () => {
+    const h1 = page.querySelector("h1");
+    expect(h1).toBeTruthy();
+    expect(cleanText(h1?.textContent)).toMatch(/Evan/);
+  });
+
+  it("renders the VitePress hero block", () => {
+    expect(page.querySelector(".VPHero, .vp-hero")).toBeTruthy();
+  });
+
+  it("renders the llms-card callout", () => {
+    expect(page.querySelector(".llms-card")).toBeTruthy();
+  });
+
+  it("links to at least one blog post (featured grid)", () => {
+    const postLinks = page.querySelectorAll('a[href^="/blog/post/"]');
+    expect(postLinks.length).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/rendering/llms-and-sitemap.test.ts
+++ b/__tests__/rendering/llms-and-sitemap.test.ts
@@ -1,0 +1,36 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { distPath } from "./_helpers";
+
+describe("generated artifacts", () => {
+  it("emits llms.txt with non-trivial content", () => {
+    const file = distPath("llms.txt");
+    expect(existsSync(file), "llms.txt should exist").toBe(true);
+    expect(statSync(file).size).toBeGreaterThan(100);
+  });
+
+  it("emits llms-full.txt with substantial content", () => {
+    const file = distPath("llms-full.txt");
+    expect(existsSync(file), "llms-full.txt should exist").toBe(true);
+    expect(statSync(file).size).toBeGreaterThan(1000);
+  });
+
+  it("emits sitemap.xml that includes the home URL", () => {
+    const file = distPath("sitemap.xml");
+    expect(existsSync(file), "sitemap.xml should exist").toBe(true);
+    const xml = readFileSync(file, "utf8");
+    expect(xml).toContain("<loc>https://www.evantahler.com/</loc>");
+  });
+
+  it("excludes per-tag pages from the sitemap (only /blog/tags index allowed)", () => {
+    const xml = readFileSync(distPath("sitemap.xml"), "utf8");
+    // Per-tag URLs look like /blog/tag/<name>; the tags index is /blog/tags.
+    const perTag = xml.match(/\/blog\/tag\/[a-z0-9-]+/gi) ?? [];
+    expect(perTag).toEqual([]);
+  });
+
+  it("excludes the 404 page from the sitemap", () => {
+    const xml = readFileSync(distPath("sitemap.xml"), "utf8");
+    expect(xml).not.toMatch(/\/404\b/);
+  });
+});

--- a/__tests__/rendering/open-source.test.ts
+++ b/__tests__/rendering/open-source.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { cleanText, loadPage } from "./_helpers";
+
+describe("open-source page (/open-source)", () => {
+  const page = loadPage("/open-source");
+
+  it("renders an h1", () => {
+    expect(cleanText(page.querySelector("h1")?.textContent)).not.toBe("");
+  });
+
+  it("renders the 'Featured Projects' section heading", () => {
+    const headings = page
+      .querySelectorAll(".vp-doc h2")
+      .map((h) => cleanText(h.textContent));
+    expect(headings).toContain("Featured Projects");
+  });
+
+  it("renders the GitHub Sponsorships call-to-action link", () => {
+    // The repo grid is hydrated client-side from a live GitHub API call
+    // that may be rate-limited at build time, so we don't assert on
+    // individual repo cards. The sponsorship link is in the markdown
+    // and must always render.
+    const sponsorship = page.querySelector(
+      '.vp-doc a[href*="github.com/users/evantahler/sponsorship"]',
+    );
+    expect(sponsorship).toBeTruthy();
+  });
+
+  it("body has the intro markdown content", () => {
+    const text = page.querySelector(".vp-doc")?.textContent ?? "";
+    expect(text).toMatch(/open source/i);
+    expect(text.length).toBeGreaterThan(200);
+  });
+});

--- a/__tests__/rendering/resume.test.ts
+++ b/__tests__/rendering/resume.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { cleanText, loadPage } from "./_helpers";
+
+describe("resume page (/resume)", () => {
+  const page = loadPage("/resume");
+
+  it("renders an h1", () => {
+    expect(cleanText(page.querySelector("h1")?.textContent)).not.toBe("");
+  });
+
+  it("renders at least one section heading", () => {
+    const headings = page.querySelectorAll(".vp-doc h2, .vp-doc h3");
+    expect(headings.length).toBeGreaterThan(0);
+  });
+
+  it("renders the resume photo", () => {
+    const imgs = page.querySelectorAll(".vp-doc img");
+    expect(imgs.length).toBeGreaterThan(0);
+    expect(imgs[0].getAttribute("src")).toBeTruthy();
+  });
+
+  it("contains the word 'Engineer' (preserves prior smoke-test intent)", () => {
+    const text = page.querySelector(".vp-doc")?.textContent ?? "";
+    expect(text).toMatch(/Engineer/i);
+  });
+
+  it("body has non-trivial content", () => {
+    const text = page.querySelector(".vp-doc")?.textContent ?? "";
+    expect(text.length).toBeGreaterThan(800);
+  });
+});

--- a/__tests__/rendering/setup.ts
+++ b/__tests__/rendering/setup.ts
@@ -1,0 +1,33 @@
+export default async function setup() {
+  // Real implementation lives below. The rendering suite needs the
+  // VitePress build output in .vitepress/dist/. Set SKIP_BUILD=1 to
+  // reuse an existing build (e.g. CI's prior `bun run build` step).
+  // Set SKIP_RENDERING=1 to skip building entirely (e.g. when running
+  // only data/content/component suites locally).
+  if (process.env.SKIP_RENDERING === "1" || process.env.SKIP_BUILD === "1") {
+    return;
+  }
+
+  const { existsSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  const { spawnSync } = await import("node:child_process");
+
+  const distIndex = join(process.cwd(), ".vitepress", "dist", "index.html");
+
+  // eslint-disable-next-line no-console
+  console.log("[vitest setup] Running `vitepress build` for rendering tests…");
+  const result = spawnSync("bunx", ["vitepress", "build"], {
+    stdio: "inherit",
+    env: { ...process.env, NODE_ENV: "production" },
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `vitepress build failed (exit ${result.status}). Cannot run rendering tests.`,
+    );
+  }
+  if (!existsSync(distIndex)) {
+    throw new Error(
+      `Build completed but ${distIndex} is missing — vitepress output layout may have changed.`,
+    );
+  }
+}

--- a/__tests__/rendering/speaking.test.ts
+++ b/__tests__/rendering/speaking.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { talks } from "../../data/talks";
+import { cleanText, loadPage } from "./_helpers";
+
+describe("speaking page (/speaking)", () => {
+  const page = loadPage("/speaking");
+  const bodyText = page.querySelector(".vp-doc")?.textContent ?? "";
+  const imgSrcs = new Set(
+    page
+      .querySelectorAll(".vp-doc img")
+      .map((i) => i.getAttribute("src") ?? ""),
+  );
+  const linkHrefs = new Set(
+    page
+      .querySelectorAll('.vp-doc a[href^="http"]')
+      .map((a) => a.getAttribute("href") ?? ""),
+  );
+
+  it("renders an h1", () => {
+    expect(cleanText(page.querySelector("h1")?.textContent)).not.toBe("");
+  });
+
+  it.each(talks)("'$title' is rendered with title text", (talk) => {
+    expect(bodyText).toContain(talk.title);
+  });
+
+  it.each(talks)("'$title' is rendered with image", (talk) => {
+    expect(imgSrcs.has(talk.image)).toBe(true);
+  });
+
+  it.each(
+    talks.filter((t) => t.links.length > 0),
+  )("'$title' has at least one of its declared links", (talk) => {
+    const found = talk.links.some((l) => linkHrefs.has(l.url));
+    expect(
+      found,
+      `Expected one of ${JSON.stringify(talk.links.map((l) => l.url))}`,
+    ).toBe(true);
+  });
+});

--- a/biome.json
+++ b/biome.json
@@ -12,7 +12,8 @@
       "!.vitepress/cache",
       "!.vitepress/dist",
       "!blog/post",
-      "!public"
+      "!public",
+      "!coverage"
     ]
   },
   "formatter": {

--- a/blog/post/2020-02-18-production-node-applications-with-docker.md
+++ b/blog/post/2020-02-18-production-node-applications-with-docker.md
@@ -18,7 +18,6 @@ tags:
   - devops
 image: /images/medium-export/1__lOqD__NHM7gQY9Ax9TF4wZg.jpeg
 featured: true
-canonical: null
 ---
 
 ![](/images/medium-export/1__lOqD__NHM7gQY9Ax9TF4wZg.jpeg)

--- a/blog/post/2020-03-01-actionhero-developer-survey-results.md
+++ b/blog/post/2020-03-01-actionhero-developer-survey-results.md
@@ -10,7 +10,6 @@ tags:
   - javascript
   - node.js
 featured: false
-canonical: null
 image: /images/medium-export/1__xttMYnX__HSXA2VFjXiS__Tw.png
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,9 +11,15 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",
         "@types/node": "^25.5.0",
+        "@vitejs/plugin-vue": "^6.0.6",
+        "@vitest/coverage-v8": "^4.1.5",
+        "@vue/test-utils": "^2.4.10",
+        "happy-dom": "^20.9.0",
+        "node-html-parser": "^7.1.0",
         "typescript": "^5.9.3",
         "vitepress": "^1.6.4",
         "vitepress-plugin-llms": "^1.12.1",
+        "vitest": "^4.1.5",
         "vue": "^3.5.33",
       },
     },
@@ -63,6 +69,8 @@
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
+
     "@biomejs/biome": ["@biomejs/biome@2.4.13", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.13", "@biomejs/cli-darwin-x64": "2.4.13", "@biomejs/cli-linux-arm64": "2.4.13", "@biomejs/cli-linux-arm64-musl": "2.4.13", "@biomejs/cli-linux-x64": "2.4.13", "@biomejs/cli-linux-x64-musl": "2.4.13", "@biomejs/cli-win32-arm64": "2.4.13", "@biomejs/cli-win32-x64": "2.4.13" }, "bin": { "biome": "bin/biome" } }, "sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA=="],
 
     "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg=="],
@@ -86,6 +94,12 @@
     "@docsearch/js": ["@docsearch/js@3.8.2", "", { "dependencies": { "@docsearch/react": "3.8.2", "preact": "^10.0.0" } }, "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ=="],
 
     "@docsearch/react": ["@docsearch/react@3.8.2", "", { "dependencies": { "@algolia/autocomplete-core": "1.17.7", "@algolia/autocomplete-preset-algolia": "1.17.7", "@docsearch/css": "3.8.2", "algoliasearch": "^5.14.2" }, "peerDependencies": { "@types/react": ">= 16.8.0 < 19.0.0", "react": ">= 16.8.0 < 19.0.0", "react-dom": ">= 16.8.0 < 19.0.0", "search-insights": ">= 1 < 3" }, "optionalPeers": ["@types/react", "react", "react-dom", "search-insights"] }, "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg=="],
+
+    "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 
@@ -137,7 +151,19 @@
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
+
+    "@one-ini/wasm": ["@one-ini/wasm@0.1.1", "", {}, "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
 
     "@parcel/watcher": ["@parcel/watcher@2.5.4", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.3" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.4", "@parcel/watcher-darwin-arm64": "2.5.4", "@parcel/watcher-darwin-x64": "2.5.4", "@parcel/watcher-freebsd-x64": "2.5.4", "@parcel/watcher-linux-arm-glibc": "2.5.4", "@parcel/watcher-linux-arm-musl": "2.5.4", "@parcel/watcher-linux-arm64-glibc": "2.5.4", "@parcel/watcher-linux-arm64-musl": "2.5.4", "@parcel/watcher-linux-x64-glibc": "2.5.4", "@parcel/watcher-linux-x64-musl": "2.5.4", "@parcel/watcher-win32-arm64": "2.5.4", "@parcel/watcher-win32-ia32": "2.5.4", "@parcel/watcher-win32-x64": "2.5.4" } }, "sha512-WYa2tUVV5HiArWPB3ydlOc4R2ivq0IDrlqhMi3l7mVsFEXNcTfxYFPIHXHXIh/ca/y/V5N4E1zecyxdIBjYnkQ=="],
 
@@ -166,6 +192,40 @@
     "@parcel/watcher-win32-ia32": ["@parcel/watcher-win32-ia32@2.5.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-vQN+KIReG0a2ZDpVv8cgddlf67J8hk1WfZMMP7sMeZmJRSmEax5xNDNWKdgqSe2brOKTQQAs3aCCUal2qBHAyg=="],
 
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-3A6efb6BOKwyw7yk9ro2vus2YTt2nvcd56AuzxdMiVOxL9umDyN5PKkKfZ/gZ9row41SjVmTVQNWQhaRRGpOKw=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.17", "", { "os": "android", "cpu": "arm64" }, "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "x64" }, "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.17", "", { "os": "freebsd", "cpu": "x64" }, "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm" }, "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "ppc64" }, "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "s390x" }, "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.17", "", { "os": "none", "cpu": "arm64" }, "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.17", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "arm64" }, "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "x64" }, "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.13", "", {}, "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.2", "", { "os": "android", "cpu": "arm" }, "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw=="],
 
@@ -233,7 +293,15 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -255,11 +323,31 @@
 
     "@types/web-bluetooth": ["@types/web-bluetooth@0.0.21", "", {}, "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vercel/analytics": ["@vercel/analytics@2.0.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g=="],
 
-    "@vitejs/plugin-vue": ["@vitejs/plugin-vue@5.2.4", "", { "peerDependencies": { "vite": "^5.0.0 || ^6.0.0", "vue": "^3.2.25" } }, "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA=="],
+    "@vitejs/plugin-vue": ["@vitejs/plugin-vue@6.0.6", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.13" }, "peerDependencies": { "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0", "vue": "^3.2.25" } }, "sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg=="],
+
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.5", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.5", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.5", "vitest": "4.1.5" }, "optionalPeers": ["@vitest/browser"] }, "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.5", "", { "dependencies": { "@vitest/spy": "4.1.5", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.5", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.5", "", { "dependencies": { "@vitest/utils": "4.1.5", "pathe": "^2.0.3" } }, "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "@vitest/utils": "4.1.5", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.5", "", {}, "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
 
     "@vue/compiler-core": ["@vue/compiler-core@3.5.33", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.33", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw=="],
 
@@ -285,6 +373,8 @@
 
     "@vue/shared": ["@vue/shared@3.5.33", "", {}, "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ=="],
 
+    "@vue/test-utils": ["@vue/test-utils@2.4.10", "", { "dependencies": { "js-beautify": "^1.14.9", "vue-component-type-helpers": "^3.0.0" }, "peerDependencies": { "@vue/compiler-dom": "3.x", "@vue/server-renderer": "3.x", "vue": "3.x" }, "optionalPeers": ["@vue/server-renderer"] }, "sha512-SmoZ5EA1kYiAFs9NkYdiFFQF+cSnUwnvlYEbY+DogWQZUiqOm/Y29eSbc5T6yi75SgSF9863SBeXniIEoPajCA=="],
+
     "@vueuse/core": ["@vueuse/core@12.8.2", "", { "dependencies": { "@types/web-bluetooth": "^0.0.21", "@vueuse/metadata": "12.8.2", "@vueuse/shared": "12.8.2", "vue": "^3.5.13" } }, "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ=="],
 
     "@vueuse/integrations": ["@vueuse/integrations@12.8.2", "", { "dependencies": { "@vueuse/core": "12.8.2", "@vueuse/shared": "12.8.2", "vue": "^3.5.13" }, "peerDependencies": { "async-validator": "^4", "axios": "^1", "change-case": "^5", "drauu": "^0.4", "focus-trap": "^7", "fuse.js": "^7", "idb-keyval": "^6", "jwt-decode": "^4", "nprogress": "^0.2", "qrcode": "^1.5", "sortablejs": "^1", "universal-cookie": "^7" }, "optionalPeers": ["async-validator", "axios", "change-case", "drauu", "focus-trap", "fuse.js", "idb-keyval", "jwt-decode", "nprogress", "qrcode", "sortablejs", "universal-cookie"] }, "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g=="],
@@ -292,6 +382,8 @@
     "@vueuse/metadata": ["@vueuse/metadata@12.8.2", "", {}, "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A=="],
 
     "@vueuse/shared": ["@vueuse/shared@12.8.2", "", { "dependencies": { "vue": "^3.5.13" } }, "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w=="],
+
+    "abbrev": ["abbrev@2.0.0", "", {}, "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="],
 
     "algoliasearch": ["algoliasearch@5.52.0", "", { "dependencies": { "@algolia/abtesting": "1.18.0", "@algolia/client-abtesting": "5.52.0", "@algolia/client-analytics": "5.52.0", "@algolia/client-common": "5.52.0", "@algolia/client-insights": "5.52.0", "@algolia/client-personalization": "5.52.0", "@algolia/client-query-suggestions": "5.52.0", "@algolia/client-search": "5.52.0", "@algolia/ingestion": "1.52.0", "@algolia/monitoring": "1.52.0", "@algolia/recommend": "5.52.0", "@algolia/requester-browser-xhr": "5.52.0", "@algolia/requester-fetch": "5.52.0", "@algolia/requester-node-http": "5.52.0" } }, "sha512-0ZzY9mjqV7gop/AH8pIBiAS8giXP7WcSiUfoFYIzYAK9QC5c37E4SIVtJVBMwlURc0/uNt2o4RcNRvdHa4CJ5w=="],
 
@@ -301,15 +393,23 @@
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg=="],
+
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "birpc": ["birpc@2.9.0", "", {}, "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw=="],
 
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
@@ -327,7 +427,19 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
+    "commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
+
+    "config-chain": ["config-chain@1.1.13", "", { "dependencies": { "ini": "^1.3.4", "proto-list": "~1.2.1" } }, "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
     "copy-anything": ["copy-anything@4.0.5", "", { "dependencies": { "is-what": "^5.2.0" } }, "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -341,11 +453,25 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "editorconfig": ["editorconfig@1.0.7", "", { "dependencies": { "@one-ini/wasm": "0.1.1", "commander": "^10.0.0", "minimatch": "^9.0.1", "semver": "^7.5.3" }, "bin": { "editorconfig": "bin/editorconfig" } }, "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw=="],
+
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "emoji-regex-xs": ["emoji-regex-xs@1.0.0", "", {}, "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
 
     "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
@@ -355,7 +481,9 @@
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
-    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -363,7 +491,11 @@
 
     "fault": ["fault@2.0.1", "", { "dependencies": { "format": "^0.2.0" } }, "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ=="],
 
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
     "focus-trap": ["focus-trap@7.8.0", "", { "dependencies": { "tabbable": "^6.4.0" } }, "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA=="],
+
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
     "format": ["format@0.2.2", "", {}, "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="],
 
@@ -371,17 +503,29 @@
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
+    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
+
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
+    "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
+
     "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
+
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "immutable": ["immutable@5.1.5", "", {}, "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A=="],
+
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 
@@ -395,15 +539,61 @@
 
     "is-what": ["is-what@5.5.0", "", {}, "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw=="],
 
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "js-beautify": ["js-beautify@1.15.4", "", { "dependencies": { "config-chain": "^1.1.13", "editorconfig": "^1.0.4", "glob": "^10.4.2", "js-cookie": "^3.0.5", "nopt": "^7.2.1" }, "bin": { "css-beautify": "js/bin/css-beautify.js", "html-beautify": "js/bin/html-beautify.js", "js-beautify": "js/bin/js-beautify.js" } }, "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA=="],
+
+    "js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
+
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+
     "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.5.2", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "mark.js": ["mark.js@8.11.1", "", {}, "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="],
 
@@ -473,6 +663,8 @@
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
     "minisearch": ["minisearch@7.2.0", "", {}, "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg=="],
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
@@ -483,9 +675,25 @@
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
+    "node-html-parser": ["node-html-parser@7.1.0", "", { "dependencies": { "css-select": "^5.1.0", "he": "1.2.0" } }, "sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ=="],
+
+    "nopt": ["nopt@7.2.1", "", { "dependencies": { "abbrev": "^2.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
     "oniguruma-to-es": ["oniguruma-to-es@3.1.1", "", { "dependencies": { "emoji-regex-xs": "^1.0.0", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ=="],
 
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
 
@@ -500,6 +708,8 @@
     "pretty-bytes": ["pretty-bytes@7.1.0", "", {}, "sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
@@ -523,6 +733,8 @@
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
+    "rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
+
     "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
 
     "sass": ["sass@1.98.0", "", { "dependencies": { "chokidar": "^4.0.0", "immutable": "^5.1.5", "source-map-js": ">=0.6.2 <2.0.0" }, "optionalDependencies": { "@parcel/watcher": "^2.4.1" }, "bin": { "sass": "sass.js" } }, "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A=="],
@@ -531,7 +743,17 @@
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "shiki": ["shiki@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/langs": "2.5.0", "@shikijs/themes": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -541,23 +763,43 @@
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
+
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
 
     "superjson": ["superjson@2.2.6", "", { "dependencies": { "copy-anything": "^4" } }, "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA=="],
 
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
     "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "tokenx": ["tokenx@1.3.0", "", {}, "sha512-NLdXTEZkKiO0gZuLtMoZKjCXTREXeZZt8nnnNeyoXtNZAfG/GKGSbQtLU5STspc0rMSwcA+UJfWZkbNU01iKmQ=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -583,15 +825,29 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
-    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+    "vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
 
     "vitepress": ["vitepress@1.6.4", "", { "dependencies": { "@docsearch/css": "3.8.2", "@docsearch/js": "3.8.2", "@iconify-json/simple-icons": "^1.2.21", "@shikijs/core": "^2.1.0", "@shikijs/transformers": "^2.1.0", "@shikijs/types": "^2.1.0", "@types/markdown-it": "^14.1.2", "@vitejs/plugin-vue": "^5.2.1", "@vue/devtools-api": "^7.7.0", "@vue/shared": "^3.5.13", "@vueuse/core": "^12.4.0", "@vueuse/integrations": "^12.4.0", "focus-trap": "^7.6.4", "mark.js": "8.11.1", "minisearch": "^7.1.1", "shiki": "^2.1.0", "vite": "^5.4.14", "vue": "^3.5.13" }, "peerDependencies": { "markdown-it-mathjax3": "^4", "postcss": "^8" }, "optionalPeers": ["markdown-it-mathjax3", "postcss"], "bin": { "vitepress": "bin/vitepress.js" } }, "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg=="],
 
     "vitepress-plugin-llms": ["vitepress-plugin-llms@1.12.1", "", { "dependencies": { "gray-matter": "^4.0.3", "markdown-it": "^14.1.0", "markdown-title": "^1.0.2", "mdast-util-from-markdown": "^2.0.3", "millify": "^6.1.0", "minimatch": "^10.2.5", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "pretty-bytes": "^7.1.0", "remark": "^15.0.1", "remark-frontmatter": "^5.0.0", "tokenx": "^1.3.0", "unist-util-remove": "^4.0.0", "unist-util-visit": "^5.1.0" } }, "sha512-mUbjxXbNCWIxTZPuxh1smbjRpU1j5Bw5sXKoWeU/kfWCyALE92HyiAXhOgNVAB8QOLCuXticf3Qwsj/YlWROlw=="],
 
+    "vitest": ["vitest@4.1.5", "", { "dependencies": { "@vitest/expect": "4.1.5", "@vitest/mocker": "4.1.5", "@vitest/pretty-format": "4.1.5", "@vitest/runner": "4.1.5", "@vitest/snapshot": "4.1.5", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.5", "@vitest/browser-preview": "4.1.5", "@vitest/browser-webdriverio": "4.1.5", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg=="],
+
     "vue": ["vue@3.5.33", "", { "dependencies": { "@vue/compiler-dom": "3.5.33", "@vue/compiler-sfc": "3.5.33", "@vue/runtime-dom": "3.5.33", "@vue/server-renderer": "3.5.33", "@vue/shared": "3.5.33" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ=="],
 
+    "vue-component-type-helpers": ["vue-component-type-helpers@3.2.7", "", {}, "sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -601,8 +857,48 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "@vue/compiler-core/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@vue/compiler-sfc/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "editorconfig/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
+
+    "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "vite/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "vitepress/@vitejs/plugin-vue": ["@vitejs/plugin-vue@5.2.4", "", { "peerDependencies": { "vite": "^5.0.0 || ^6.0.0", "vue": "^3.2.25" } }, "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA=="],
+
+    "vitepress/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "editorconfig/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+
+    "editorconfig/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }
 }

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,4 @@
+[test]
+# Tests are run by Vitest (`bun run test`), not Bun's built-in test runner.
+# This preload prints a redirect message and exits if anyone runs `bun test`.
+preload = ["./scripts/bun-test-guard.ts"]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
     "build": "vitepress build",
     "preview": "vitepress preview",
     "lint": "biome check .",
-    "format": "biome format --write ."
+    "format": "biome format --write .",
+    "test": "vitest run",
+    "test:unit": "SKIP_RENDERING=1 vitest run __tests__/data __tests__/content __tests__/components",
+    "test:watch": "SKIP_RENDERING=1 vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
@@ -24,9 +28,15 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",
     "@types/node": "^25.5.0",
+    "@vitejs/plugin-vue": "^6.0.6",
+    "@vitest/coverage-v8": "^4.1.5",
+    "@vue/test-utils": "^2.4.10",
+    "happy-dom": "^20.9.0",
+    "node-html-parser": "^7.1.0",
     "typescript": "^5.9.3",
     "vitepress": "^1.6.4",
     "vitepress-plugin-llms": "^1.12.1",
+    "vitest": "^4.1.5",
     "vue": "^3.5.33"
   }
 }

--- a/scripts/bun-test-guard.ts
+++ b/scripts/bun-test-guard.ts
@@ -1,0 +1,17 @@
+// Bun's built-in test runner doesn't support this project's tests
+// (Vitest's vi.mock semantics, @vue/test-utils + happy-dom). Loaded via
+// `bunfig.toml` [test] preload so `bun test` exits before discovering
+// any test files.
+
+console.error(
+  [
+    "",
+    "\x1b[31m[bun test] This project uses Vitest, not Bun's built-in test runner.\x1b[0m",
+    "",
+    "  \x1b[32mbun run test\x1b[0m         — full suite (builds the site, runs all 242 tests)",
+    "  \x1b[32mbun run test:unit\x1b[0m    — fast suite (data + content + component, no build)",
+    "  \x1b[32mbun run test:coverage\x1b[0m",
+    "",
+  ].join("\n"),
+);
+process.exit(1);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,31 @@
+import vue from "@vitejs/plugin-vue";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: "happy-dom",
+    globals: true,
+    include: ["__tests__/**/*.test.ts"],
+    globalSetup: ["__tests__/rendering/setup.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      all: true,
+      include: [
+        ".vitepress/data/**/*.ts",
+        ".vitepress/theme/**/*.{ts,vue}",
+        "data/**/*.ts",
+        "blog/tag/**/*.ts",
+      ],
+      exclude: [
+        ".vitepress/cache/**",
+        ".vitepress/dist/**",
+        // Live GitHub API loader — covered by the integration build, not unit tests.
+        ".vitepress/data/github.data.ts",
+        // Theme entry — Vercel Analytics injection runs only in a real browser.
+        ".vitepress/theme/index.ts",
+      ],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Adds a Vitest-based test suite (242 tests across 20 files) covering data loaders, frontmatter integrity across every blog post, the `BlogPostHeader.vue` component, and built-HTML rendering for every page type (home, blog index/post/tag, speaking, open-source, resume, contact, 404, llms.txt, sitemap.xml).
- CI now runs `bun run test` after the build with `SKIP_BUILD=1` so the rendering suite reuses the prior step's `dist/`; `bunfig.toml` redirects accidental `bun test` invocations to `bun run test`.
- The frontmatter test caught two posts shipping `canonical: null` — cleaned up here.

## Test plan

- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test` (cold) — 242 tests pass
- [x] `bun run test:unit` (~0.5s, no build) — 185 tests pass
- [x] `bun run test:coverage` — 100% on `posts.data.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)