### PR TITLE
Restore vitepress-plugin-llms injectLLMHint

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -139,7 +139,6 @@ export default defineConfig({
     plugins: [
       llmstxt({
         ignoreFiles: ["blog/tag/**", "blog/tags.md", "404.md"],
-        injectLLMHint: false,
       }),
       builtAssetDevServer,
     ],


### PR DESCRIPTION
## Summary
- Reverts the `injectLLMHint: false` from #485. That disable was a misdiagnosis — the actual cause of "body disappears on hard refresh" was Vercel returning 404 for clean URLs (fixed in #487), not a Vue hydration mismatch.
- Verified locally: with the hint re-enabled, the built HTML has the hint **and** the post body, and the page module's static-VNode count (56) matches the rendered DOM child count (56).
- Brings back the per-page "Are you an LLM? You can read better optimized documentation at /…/foo.md" hidden notice.

## Test plan
- [ ] After deploy, hard-load `/blog/post/2026-03-13-curl-for-mcp` — body and "On this page" sidebar render.
- [ ] Page source contains the `Are you an LLM?` hidden div.
- [ ] `/llms.txt`, `/llms-full.txt`, `/blog/post/<slug>.md` still 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)