### PR TITLE
Add Conductor workspace setup

### DIFF
--- a/.conductor/archive.sh
+++ b/.conductor/archive.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+MAIN=$(git worktree list --porcelain | head -1 | sed 's/worktree //')
+MAIN_BRANCH=$(git -C "$MAIN" rev-parse --abbrev-ref HEAD)
+
+if [ "$MAIN_BRANCH" = "main" ]; then
+  echo "Main worktree is on main — pulling latest"
+  git -C "$MAIN" pull
+else
+  echo "Main worktree is on $MAIN_BRANCH — fetching"
+  git -C "$MAIN" fetch
+fi

--- a/.conductor/setup.sh
+++ b/.conductor/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+bun install

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "setup": "bash .conductor/setup.sh",
+    "archive": "bash .conductor/archive.sh"
+  }
+}


### PR DESCRIPTION
## Summary

Adds `conductor.json` plus `.conductor/setup.sh` and `.conductor/archive.sh` so new Conductor workspaces auto-run `bun install` on creation, and archiving a workspace pulls (or fetches) the main worktree to keep its branch fresh. Pattern mirrors the existing setup in `~/workspace/macos-ts`.

## Test plan

- [x] `bash -n` syntax-check on both scripts
- [x] `bash .conductor/setup.sh` installs cleanly in this workspace
- [ ] Archive this workspace once merged to confirm `archive.sh` refreshes the main worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)