### PR TITLE
Emit <link rel="canonical"> in the HTML head

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -4,6 +4,19 @@ import type { Plugin, ViteDevServer } from "vite";
 import { defineConfig } from "vitepress";
 import llmstxt from "vitepress-plugin-llms";
 
+const SITE_URL = "https://www.evantahler.com";
+
+const skipCanonical = (path: string) =>
+  path.startsWith("blog/tag/") || path === "blog/tags.md" || path === "404.md";
+
+function pageUrlFromRelativePath(relativePath: string): string {
+  const noExt = relativePath.replace(/\.md$/, "");
+  if (noExt === "index") return `${SITE_URL}/`;
+  if (noExt.endsWith("/index"))
+    return `${SITE_URL}/${noExt.slice(0, -"index".length)}`;
+  return `${SITE_URL}/${noExt}`;
+}
+
 // VitePress only generates llms.txt, llms-full.txt, and sitemap.xml at build
 // time, and vitepress-plugin-llms 1.12.1's dev middleware rewrites every
 // request to `.md` (so even /llms.txt falls through). Serve those static
@@ -82,7 +95,7 @@ export default defineConfig({
   ],
 
   sitemap: {
-    hostname: "https://www.evantahler.com",
+    hostname: SITE_URL,
     transformItems(items) {
       return items.filter((item) => {
         const url = item.url || "";
@@ -132,6 +145,13 @@ export default defineConfig({
     const path = pageData.relativePath;
     if (path.startsWith("blog/tag/") || path === "404.md") {
       pageData.frontmatter.sitemap = { exclude: true };
+    }
+
+    const explicitCanonical = pageData.frontmatter.canonical;
+    if (explicitCanonical || !skipCanonical(path)) {
+      const href = explicitCanonical ?? pageUrlFromRelativePath(path);
+      pageData.frontmatter.head = pageData.frontmatter.head ?? [];
+      pageData.frontmatter.head.push(["link", { rel: "canonical", href }]);
     }
   },
 

--- a/__tests__/rendering/blog-post.test.ts
+++ b/__tests__/rendering/blog-post.test.ts
@@ -76,6 +76,24 @@ describe("blog post (/blog/post/<slug>)", () => {
   });
 });
 
+describe("blog post without canonical frontmatter", () => {
+  const sampleNoCanonical = POSTS.find((p) => !p.meta.canonical);
+
+  if (!sampleNoCanonical) {
+    it.skip("no post without canonical found", () => {});
+    return;
+  }
+
+  it("emits a self-referential canonical link in the head", () => {
+    const page = loadPage(sampleNoCanonical.url);
+    const link = page.querySelector('head link[rel="canonical"]');
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute("href")).toBe(
+      `https://www.evantahler.com/blog/post/${sampleNoCanonical.slug}`,
+    );
+  });
+});
+
 describe("blog post with canonical link", () => {
   const sampleWithCanonical = POSTS.find((p) => p.meta.canonical);
 
@@ -93,5 +111,12 @@ describe("blog post with canonical link", () => {
     );
     expect(link, "canonical link should appear in meta").toBeTruthy();
     expect(link?.getAttribute("target")).toBe("_blank");
+  });
+
+  it("emits an external canonical link in the head", () => {
+    const page = loadPage(sampleWithCanonical.url);
+    const link = page.querySelector('head link[rel="canonical"]');
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute("href")).toBe(sampleWithCanonical.meta.canonical);
   });
 });

--- a/__tests__/rendering/blog-tag.test.ts
+++ b/__tests__/rendering/blog-tag.test.ts
@@ -47,4 +47,8 @@ describe("blog tag page (/blog/tag/<tag>)", () => {
     }
     expect(renderedHrefs.size).toBe(expectedSlugs.size);
   });
+
+  it("does not emit a canonical link in the head", () => {
+    expect(page.querySelector('head link[rel="canonical"]')).toBeFalsy();
+  });
 });

--- a/__tests__/rendering/home.test.ts
+++ b/__tests__/rendering/home.test.ts
@@ -28,4 +28,10 @@ describe("home page (/)", () => {
     const postLinks = page.querySelectorAll('a[href^="/blog/post/"]');
     expect(postLinks.length).toBeGreaterThan(0);
   });
+
+  it("emits a self-referential canonical link in the head", () => {
+    const link = page.querySelector('head link[rel="canonical"]');
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute("href")).toBe("https://www.evantahler.com/");
+  });
 });

--- a/__tests__/rendering/resume.test.ts
+++ b/__tests__/rendering/resume.test.ts
@@ -28,4 +28,12 @@ describe("resume page (/resume)", () => {
     const text = page.querySelector(".vp-doc")?.textContent ?? "";
     expect(text.length).toBeGreaterThan(800);
   });
+
+  it("emits a self-referential canonical link in the head", () => {
+    const link = page.querySelector('head link[rel="canonical"]');
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute("href")).toBe(
+      "https://www.evantahler.com/resume",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Cross-posts (those with a `canonical:` frontmatter) now emit `<link rel="canonical" href="<external-url>">` in the head — previously the field was only used by `BlogPostHeader.vue` for the visible "Originally posted at..." line, leaving search engines no signal about the original source.
- Every other page gets a self-referential canonical built from the srcDir-relative path; tag pages, `/blog/tags`, and `/404` are skipped to mirror the sitemap exclusion set.
- `SITE_URL` is hoisted as a constant and reused by `sitemap.hostname` so the two stay in sync.
- Five new rendering assertions cover the cross-post case, the self-canonical case on a normal post + `/` + `/resume`, and the negative case on tag pages.

## Test plan

- [x] `bun run lint`
- [x] `bun run build` — spot-checked dist HTML for `/`, `/resume`, `/blog/`, a normal post, an Arcade cross-post, and a tag page
- [x] `bun run test` (249 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)