### PR TITLE
Gitignore Conductor .context/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules
 .vitepress/dist
 public/sitemap*.xml
 coverage
+
+# Conductor workspace context
+.context/


### PR DESCRIPTION
## Summary

Adds `.context/` to `.gitignore`. Conductor writes per-workspace scratch files there (notes, plans, attachments) and the project CLAUDE.md already documents it as gitignored — but currently it's only excluded via local `.git/info/exclude`, so fresh clones or other machines would track it. Mirrors the macos-ts setup. Follow-up to #491.

## Test plan

- [x] `git check-ignore .context/` resolves to the tracked `.gitignore` after merge