### PR TITLE
Restore Google Analytics

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -79,6 +79,21 @@ export default defineConfig({
     ["link", { rel: "manifest", href: "/site.webmanifest" }],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
     ["meta", { name: "twitter:site", content: "@evantahler" }],
+    [
+      "script",
+      {
+        async: "",
+        src: "https://www.googletagmanager.com/gtag/js?id=G-VY35SQM9Y1",
+      },
+    ],
+    [
+      "script",
+      {},
+      `window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', 'G-VY35SQM9Y1');`,
+    ],
   ],
 
   sitemap: {

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -16,9 +16,11 @@ const theme: Theme = {
       import("@vercel/analytics").then(({ inject }) => {
         inject();
       });
-      router.onAfterRouteChanged = () => {
+      router.onAfterRouteChanged = (to) => {
         // @ts-expect-error vercel analytics global
         window.va?.("event", { name: "pageview" });
+        // @ts-expect-error gtag global
+        window.gtag?.("event", "page_view", { page_path: to });
       };
     }
   },

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "@vue/test-utils": "^2.4.10",
         "happy-dom": "^20.9.0",
         "node-html-parser": "^7.1.0",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vitepress": "^1.6.4",
         "vitepress-plugin-llms": "^1.12.1",
         "vitest": "^4.1.5",
@@ -801,7 +801,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 


### PR DESCRIPTION
## Summary
- Restores Google Analytics (GA4 property `G-VY35SQM9Y1`) — dropped during the Next.js → VitePress migration. `gtag.js` loads via `head[]` in `.vitepress/config.ts`, and the existing `router.onAfterRouteChanged` hook in `.vitepress/theme/index.ts` now also fires `page_view` for SPA navigations alongside the Vercel Analytics pageview.
- Resyncs `bun.lock` with the `typescript ^6.0.3` bump from #481 (lockfile had drifted from `package.json`).

## Test plan
- [x] `bun run lint`
- [x] `bun run build` (verified `G-VY35SQM9Y1` script + inline config snippet are present in `.vitepress/dist/index.html`)
- [x] `SKIP_BUILD=1 bun run test` (244/244 passing)
- [ ] After deploy: confirm pageviews appear in GA4 Realtime under property `G-VY35SQM9Y1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)