### PR TITLE
Fix grammar in homepage hero tagline and site description

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -49,7 +49,7 @@ const builtAssetDevServer: Plugin = {
 export default defineConfig({
   title: "Evan Tahler",
   description:
-    "Evan Tahler — software engineer, leader, writer. Head of engineering at Arcade.dev, creator of Actionhero, Keryx, and more.",
+    "Evan Tahler — software engineer, leader, writer. Head of Engineering at Arcade.dev, creator of Actionhero, Keryx, and more.",
   cleanUrls: true,
   srcDir: ".",
   srcExclude: [

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ description: Evan Tahler — Software Engineer, Product Manager, and Leader. Hea
 hero:
   name: "Hi, I'm Evan!"
   text: "Software Engineering, Product Management, and Leadership."
-  tagline: I build teams that create world-class digital products. Head of engineering at Arcade.dev, creator of Actionhero, Keryx, and more.
+  tagline: I build teams that create world-class digital products. I'm Head of Engineering at Arcade.dev and the creator of Actionhero, Keryx, and more.
   image:
     src: /images/bitmoji/4.png
     alt: evan

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ description: Evan Tahler — Software Engineer, Product Manager, and Leader. Hea
 
 hero:
   name: "Hi, I'm Evan!"
-  text: "Software Engineering, Product Management, and Leadership."
+  text: "Software Engineering and Product Management Leadership."
   tagline: I build teams that create world-class digital products. I'm the Head of Engineering at Arcade.dev and the creator of Actionhero, Keryx, and more.
   image:
     src: /images/bitmoji/4.png

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ description: Evan Tahler — Software Engineer, Product Manager, and Leader. Hea
 hero:
   name: "Hi, I'm Evan!"
   text: "Software Engineering, Product Management, and Leadership."
-  tagline: I build teams that create world-class digital products. I'm Head of Engineering at Arcade.dev and the creator of Actionhero, Keryx, and more.
+  tagline: I build teams that create world-class digital products. I'm the Head of Engineering at Arcade.dev and the creator of Actionhero, Keryx, and more.
   image:
     src: /images/bitmoji/4.png
     alt: evan


### PR DESCRIPTION
- Capitalize "Engineering" in "Head of Engineering" job title
- Make the tagline a complete sentence by adding a subject