### PR TITLE
Rename /resume page to /about

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -139,7 +139,7 @@ gtag('config', 'G-VY35SQM9Y1');`,
   themeConfig: {
     siteTitle: "Evan Tahler",
     nav: [
-      { text: "Resume", link: "/resume" },
+      { text: "About", link: "/about" },
       { text: "Blog", link: "/blog" },
       { text: "Open Source", link: "/open-source" },
       { text: "Speaking", link: "/speaking" },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ CI (`.github/workflows/test.yml`) runs `bun run lint`, `bun run build`, then `SK
 
 ### VitePress layout — repo root is `srcDir`
 
-`.vitepress/config.ts` sets `srcDir: "."`, so top-level Markdown files (`index.md`, `resume.md`, `contact.md`, `speaking.md`, `open-source.md`, `404.md`) are pages. `srcExclude` keeps `README.md`, `CLAUDE.md`, and `node_modules` out of the build. Output goes to `.vitepress/dist`; cache to `.vitepress/cache` (both gitignored).
+`.vitepress/config.ts` sets `srcDir: "."`, so top-level Markdown files (`index.md`, `about.md`, `contact.md`, `speaking.md`, `open-source.md`, `404.md`) are pages. `srcExclude` keeps `README.md`, `CLAUDE.md`, and `node_modules` out of the build. Output goes to `.vitepress/dist`; cache to `.vitepress/cache` (both gitignored).
 
 ### Two parallel post loaders — pick the right one
 

--- a/__tests__/rendering/about.test.ts
+++ b/__tests__/rendering/about.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { cleanText, loadPage } from "./_helpers";
 
-describe("resume page (/resume)", () => {
-  const page = loadPage("/resume");
+describe("about page (/about)", () => {
+  const page = loadPage("/about");
 
   it("renders an h1", () => {
     expect(cleanText(page.querySelector("h1")?.textContent)).not.toBe("");
@@ -13,7 +13,7 @@ describe("resume page (/resume)", () => {
     expect(headings.length).toBeGreaterThan(0);
   });
 
-  it("renders the resume photo", () => {
+  it("renders the profile photo", () => {
     const imgs = page.querySelectorAll(".vp-doc img");
     expect(imgs.length).toBeGreaterThan(0);
     expect(imgs[0].getAttribute("src")).toBeTruthy();
@@ -32,8 +32,6 @@ describe("resume page (/resume)", () => {
   it("emits a self-referential canonical link in the head", () => {
     const link = page.querySelector('head link[rel="canonical"]');
     expect(link).toBeTruthy();
-    expect(link?.getAttribute("href")).toBe(
-      "https://www.evantahler.com/resume",
-    );
+    expect(link?.getAttribute("href")).toBe("https://www.evantahler.com/about");
   });
 });

--- a/about.md
+++ b/about.md
@@ -1,9 +1,9 @@
 ---
-title: "Evan Tahler: Resume"
-description: Evan Tahler — Head of Engineering at Arcade.dev, formerly Airbyte (via Grouparoo acquisition), Disney, TaskRabbit, ModCloth, Airbus.
+title: "About Evan Tahler"
+description: About Evan Tahler — Head of Engineering at Arcade.dev, formerly Airbyte (via Grouparoo acquisition), Disney, TaskRabbit, ModCloth, Airbus.
 ---
 
-# Resume
+# About
 
 ![evan](/images/resume-3.jpg)
 


### PR DESCRIPTION
## Summary
- Rename `resume.md` → `about.md`; H1 becomes `About`, frontmatter `title`/`description` reframed
- Nav entry in `.vitepress/config.ts` switches from `Resume → /resume` to `About → /about`
- Rendering test renamed (`resume.test.ts` → `about.test.ts`); describe block, `loadPage("/about")`, photo test name, and canonical URL assertion updated
- Top-level page list in `CLAUDE.md` updated
- No redirect from `/resume` — old inbound links will 404 (deliberate)
- `/images/resume-3.jpg` photo asset deliberately left as-is

## Test plan
- [x] `bun run lint` passes
- [x] `bun run build` succeeds; `.vitepress/dist/about.html` exists, `resume.html` does not
- [x] `bun run test` — 249/249 tests pass
- [ ] Manually visit `/about` in dev to confirm nav label is "About" and H1 renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)