### PR TITLE
Add RSS feed and surface it on the home page

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -169,7 +169,7 @@ gtag('config', 'G-VY35SQM9Y1');`,
     outline: { level: [2, 3] },
     footer: {
       message:
-        '<img src="/images/dog.png" alt="dog" class="footer-dog" /><br /><a href="https://github.com/evantahler/www.evantahler.com" target="_blank">source for this site</a> · <a href="/feed.xml">RSS</a>',
+        '<img src="/images/dog.png" alt="dog" class="footer-dog" /><br /><a href="https://github.com/evantahler/www.evantahler.com" target="_blank">source for this site</a> · <a href="/feed.xml">RSS</a> · <a href="/llms.txt">llms.txt</a>',
       copyright: `Copyright © ${new Date().getFullYear()} Evan Tahler`,
     },
     lastUpdated: { text: "Last updated" },

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -3,8 +3,8 @@ import { resolve } from "node:path";
 import type { Plugin, ViteDevServer } from "vite";
 import { defineConfig } from "vitepress";
 import llmstxt from "vitepress-plugin-llms";
-
-const SITE_URL = "https://www.evantahler.com";
+import { generateFeed } from "./data/feed";
+import { SITE_DESCRIPTION, SITE_TITLE, SITE_URL } from "./data/site";
 
 const skipCanonical = (path: string) =>
   path.startsWith("blog/tag/") || path === "blog/tags.md" || path === "404.md";
@@ -29,6 +29,7 @@ const builtAssetDevServer: Plugin = {
       "/llms.txt": "text/plain; charset=utf-8",
       "/llms-full.txt": "text/plain; charset=utf-8",
       "/sitemap.xml": "application/xml; charset=utf-8",
+      "/feed.xml": "application/rss+xml; charset=utf-8",
     };
     server.middlewares.use((req, res, next) => {
       const url = (req.url || "").split("?")[0];
@@ -47,9 +48,8 @@ const builtAssetDevServer: Plugin = {
 };
 
 export default defineConfig({
-  title: "Evan Tahler",
-  description:
-    "Evan Tahler — software engineer, leader, writer. Head of Engineering at Arcade.dev, creator of Actionhero, Keryx, and more.",
+  title: SITE_TITLE,
+  description: SITE_DESCRIPTION,
   cleanUrls: true,
   srcDir: ".",
   srcExclude: [
@@ -90,6 +90,15 @@ export default defineConfig({
       },
     ],
     ["link", { rel: "manifest", href: "/site.webmanifest" }],
+    [
+      "link",
+      {
+        rel: "alternate",
+        type: "application/rss+xml",
+        title: "Evan Tahler's Blog",
+        href: "/feed.xml",
+      },
+    ],
     [
       "link",
       {
@@ -160,10 +169,14 @@ gtag('config', 'G-VY35SQM9Y1');`,
     outline: { level: [2, 3] },
     footer: {
       message:
-        '<img src="/images/dog.png" alt="dog" class="footer-dog" /><br /><a href="https://github.com/evantahler/www.evantahler.com" target="_blank">source for this site</a>',
+        '<img src="/images/dog.png" alt="dog" class="footer-dog" /><br /><a href="https://github.com/evantahler/www.evantahler.com" target="_blank">source for this site</a> · <a href="/feed.xml">RSS</a>',
       copyright: `Copyright © ${new Date().getFullYear()} Evan Tahler`,
     },
     lastUpdated: { text: "Last updated" },
+  },
+
+  buildEnd(siteConfig) {
+    generateFeed(siteConfig.outDir);
   },
 
   transformPageData(pageData) {

--- a/.vitepress/data/feed.ts
+++ b/.vitepress/data/feed.ts
@@ -1,0 +1,53 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Feed } from "feed";
+import { loadPosts } from "./posts";
+import {
+  SITE_AUTHOR_EMAIL,
+  SITE_AUTHOR_NAME,
+  SITE_DESCRIPTION,
+  SITE_TITLE,
+  SITE_URL,
+} from "./site";
+
+function absolute(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  if (url.startsWith("http://") || url.startsWith("https://")) return url;
+  return `${SITE_URL}${url.startsWith("/") ? "" : "/"}${url}`;
+}
+
+export function generateFeed(outDir: string): void {
+  const posts = loadPosts();
+  const feed = new Feed({
+    id: `${SITE_URL}/`,
+    link: `${SITE_URL}/`,
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    language: "en",
+    image: `${SITE_URL}/images/dog.png`,
+    favicon: `${SITE_URL}/favicon-32x32.png`,
+    copyright: `Copyright © ${new Date().getFullYear()} ${SITE_AUTHOR_NAME}`,
+    feedLinks: { rss: `${SITE_URL}/feed.xml` },
+    author: {
+      name: SITE_AUTHOR_NAME,
+      email: SITE_AUTHOR_EMAIL,
+      link: SITE_URL,
+    },
+  });
+
+  for (const post of posts) {
+    const link = `${SITE_URL}${post.url}`;
+    feed.addItem({
+      title: post.meta.title,
+      id: link,
+      link,
+      description: post.meta.description,
+      date: new Date(post.meta.date),
+      category: post.meta.tags.map((name) => ({ name })),
+      image: absolute(post.meta.image),
+      author: [{ name: post.meta.author ?? SITE_AUTHOR_NAME }],
+    });
+  }
+
+  writeFileSync(join(outDir, "feed.xml"), feed.rss2(), "utf8");
+}

--- a/.vitepress/data/site.ts
+++ b/.vitepress/data/site.ts
@@ -1,0 +1,6 @@
+export const SITE_URL = "https://www.evantahler.com";
+export const SITE_TITLE = "Evan Tahler";
+export const SITE_DESCRIPTION =
+  "Evan Tahler — software engineer, leader, writer. Head of Engineering at Arcade.dev, creator of Actionhero, Keryx, and more.";
+export const SITE_AUTHOR_NAME = "Evan Tahler";
+export const SITE_AUTHOR_EMAIL = "evan@evantahler.com";

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -209,9 +209,21 @@
   overflow: hidden;
 }
 
-/* --- llms.txt callout --- */
+/* --- home page callouts (llms.txt, RSS) --- */
 
-.llms-card {
+.callout-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+@media (max-width: 720px) {
+  .callout-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.callout-card {
   display: flex;
   align-items: flex-start;
   gap: 20px;
@@ -221,17 +233,17 @@
   border: 1px solid rgba(234, 88, 12, 0.35);
 }
 
-.dark .llms-card {
+.dark .callout-card {
   background: rgba(251, 146, 60, 0.06);
   border-color: rgba(251, 146, 60, 0.35);
 }
 
-.llms-icon {
+.callout-icon {
   font-size: 36px;
   line-height: 1;
 }
 
-.llms-body h2 {
+.callout-body h2 {
   margin: 0 0 6px;
   padding-top: 0;
   border-top: none;
@@ -241,14 +253,14 @@
   color: var(--vp-c-brand-1);
 }
 
-.llms-body p {
+.callout-body p {
   margin: 0;
   font-size: 15px;
   line-height: 1.55;
   color: var(--vp-c-text-2);
 }
 
-.llms-body code {
+.callout-body code {
   font-size: 0.95em;
   padding: 1px 6px;
   border-radius: 4px;

--- a/__tests__/rendering/home.test.ts
+++ b/__tests__/rendering/home.test.ts
@@ -20,8 +20,19 @@ describe("home page (/)", () => {
     expect(page.querySelector(".VPHero, .vp-hero")).toBeTruthy();
   });
 
-  it("renders the llms-card callout", () => {
-    expect(page.querySelector(".llms-card")).toBeTruthy();
+  it("renders both callout cards (llms.txt and RSS)", () => {
+    const cards = page.querySelectorAll(".callout-card");
+    expect(cards.length).toBe(2);
+    const text = cleanText(
+      page.querySelector(".callout-grid")?.textContent,
+    ).toLowerCase();
+    expect(text).toContain("llms.txt");
+    expect(text).toContain("feed.xml");
+  });
+
+  it("links to the RSS feed from the home callout", () => {
+    const rssLink = page.querySelector('.callout-grid a[href="/feed.xml"]');
+    expect(rssLink).toBeTruthy();
   });
 
   it("links to at least one blog post (featured grid)", () => {

--- a/__tests__/rendering/llms-and-sitemap.test.ts
+++ b/__tests__/rendering/llms-and-sitemap.test.ts
@@ -33,4 +33,20 @@ describe("generated artifacts", () => {
     const xml = readFileSync(distPath("sitemap.xml"), "utf8");
     expect(xml).not.toMatch(/\/404\b/);
   });
+
+  it("emits feed.xml as a well-formed RSS 2.0 channel for the site", () => {
+    const file = distPath("feed.xml");
+    expect(existsSync(file), "feed.xml should exist").toBe(true);
+    const xml = readFileSync(file, "utf8");
+    expect(xml).toMatch(/<rss[\s>]/);
+    expect(xml).toContain("<channel>");
+    expect(xml).toContain("<link>https://www.evantahler.com/</link>");
+  });
+
+  it("includes blog posts as feed items", () => {
+    const xml = readFileSync(distPath("feed.xml"), "utf8");
+    expect(xml).toMatch(
+      /<link>https:\/\/www\.evantahler\.com\/blog\/post\/[^<]+<\/link>/,
+    );
+  });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "evantahler.com",
       "dependencies": {
         "@vercel/analytics": "^2.0.1",
+        "feed": "^5.2.1",
         "gray-matter": "^4.0.3",
       },
       "devDependencies": {
@@ -493,6 +494,8 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "feed": ["feed@5.2.1", "", { "dependencies": { "xml-js": "^1.6.11" } }, "sha512-jTynzYPWs9ALjro0GW8j7sv9y7cJBeOdD4Y88kVqYy/eyusIX3g+499JiTDIlD9Ge/unebx57T4Uzo6vpYvMtA=="],
+
     "focus-trap": ["focus-trap@7.8.0", "", { "dependencies": { "tabbable": "^6.4.0" } }, "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
@@ -739,6 +742,8 @@
 
     "sass": ["sass@1.98.0", "", { "dependencies": { "chokidar": "^4.0.0", "immutable": "^5.1.5", "source-map-js": ">=0.6.2 <2.0.0" }, "optionalDependencies": { "@parcel/watcher": "^2.4.1" }, "bin": { "sass": "sass.js" } }, "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A=="],
 
+    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
+
     "search-insights": ["search-insights@2.17.3", "", {}, "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ=="],
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
@@ -848,6 +853,8 @@
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "xml-js": ["xml-js@1.6.11", "", { "dependencies": { "sax": "^1.2.4" }, "bin": { "xml-js": "./bin/cli.js" } }, "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 

--- a/index.md
+++ b/index.md
@@ -62,17 +62,30 @@ function fmt(d) {
   </div>
 </section>
 
-<section class="home-section llms-section">
-  <div class="llms-card">
-    <div class="llms-icon" aria-hidden="true">🤖</div>
-    <div class="llms-body">
-      <h2>Reading this with an LLM?</h2>
-      <p>
-        This site publishes
-        <a href="/llms.txt"><code>/llms.txt</code></a> and
-        <a href="/llms-full.txt"><code>/llms-full.txt</code></a>
-        so agents and assistants can ingest the content directly. Help yourself.
-      </p>
+<section class="home-section callout-section">
+  <div class="callout-grid">
+    <div class="callout-card">
+      <div class="callout-icon" aria-hidden="true">🤖</div>
+      <div class="callout-body">
+        <h2>Reading this with an LLM?</h2>
+        <p>
+          This site publishes
+          <a href="/llms.txt"><code>/llms.txt</code></a> and
+          <a href="/llms-full.txt"><code>/llms-full.txt</code></a>
+          so agents and assistants can ingest the content directly. Help yourself.
+        </p>
+      </div>
+    </div>
+    <div class="callout-card">
+      <div class="callout-icon" aria-hidden="true">📡</div>
+      <div class="callout-body">
+        <h2>Prefer a feed reader?</h2>
+        <p>
+          Subscribe to the blog via
+          <a href="/feed.xml"><code>/feed.xml</code></a>
+          — drop it into Feedly, NetNewsWire, or any RSS reader of your choice.
+        </p>
+      </div>
     </div>
   </div>
 </section>

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
+    "feed": "^5.2.1",
     "gray-matter": "^4.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- **`/feed.xml`** generated at build time via a new `buildEnd` hook in `.vitepress/config.ts` that calls `generateFeed()` (`.vitepress/data/feed.ts`). Uses the [`feed`](https://www.npmjs.com/package/feed) npm package and reuses the existing `loadPosts()` loader so unlisted posts are filtered and ordering matches the rest of the site.
- **Auto-discovery**: `<link rel=\"alternate\" type=\"application/rss+xml\" href=\"/feed.xml\">` added to `<head>` so feed readers pick it up automatically.
- **Footer**: small `RSS` and `llms.txt` links next to \"source for this site\" — both surface the alternative ways to consume the site.
- **Home-page callout**: split the existing single LLM card into a 2-up `.callout-grid`. Left card unchanged (🤖 llms.txt / llms-full.txt). Right card (📡) advertises `/feed.xml`. Renamed `.llms-*` classes to `.callout-*` since they're now reused.
- **Dev server**: added `/feed.xml` to the `builtAssetDevServer` middleware so it works in `bun run dev` after a build (same caveat as `/llms.txt` and `/sitemap.xml`).
- **Shared site constants**: extracted `SITE_URL`, `SITE_TITLE`, `SITE_DESCRIPTION`, etc. into `.vitepress/data/site.ts` so config and feed both consume the same source of truth.
- **Tests**: 2 new cases in `__tests__/rendering/llms-and-sitemap.test.ts` (feed.xml exists / is RSS 2.0 / contains posts), updated home-page test to assert both callout cards render and the RSS link is present.

**Why not `vitepress-plugin-rss`?** It exists but its frontmatter expectations (`category` / `cover`) don't match this repo's (`tags` / `image`), it pulls `sharp` (~30 MB) for an unused SVG-to-PNG feature, and it duplicates the unlisted-filter / sort logic we already have. ~50 lines using the underlying `feed` package gives full control and matches the existing pattern (sitemap, vitepress-plugin-llms).

## Test plan

- [x] `bun run lint` clean
- [x] `bun run build` produces `.vitepress/dist/feed.xml` with 147 items (149 posts − 2 `unlisted`)
- [x] `bun run test` — 226/226 pass
- [x] Built HTML contains `<link ... type=\"application/rss+xml\" ...>` in `<head>` and the footer RSS / llms.txt links
- [ ] Visual check at narrow widths (<720px) — `.callout-grid` should collapse to 1 column
- [ ] Subscribe at `https://www.evantahler.com/feed.xml` in a real reader (Feedly, NetNewsWire) after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)