### PR TITLE
Editorial refresh: about, open-source, speaking, blog post + site footer

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -167,11 +167,6 @@ gtag('config', 'G-VY35SQM9Y1');`,
     ],
     search: { provider: "local" },
     outline: { level: [2, 3] },
-    footer: {
-      message:
-        '<img src="/images/dog.png" alt="dog" class="footer-dog" /><br /><a href="https://github.com/evantahler/www.evantahler.com" target="_blank">source for this site</a> · <a href="/feed.xml">RSS</a> · <a href="/llms.txt">llms.txt</a>',
-      copyright: `Copyright © ${new Date().getFullYear()} Evan Tahler`,
-    },
     lastUpdated: { text: "Last updated" },
   },
 

--- a/.vitepress/data/github.data.ts
+++ b/.vitepress/data/github.data.ts
@@ -10,11 +10,15 @@ type Repo = {
 const projects = [
   { org: "ArcadeAI", name: "arcade-mcp" },
   { org: "airbytehq", name: "airbyte" },
+  { org: "actionhero", name: "keryx" },
   { org: "grouparoo", name: "grouparoo" },
   { org: "actionhero", name: "actionhero" },
   { org: "actionhero", name: "node-resque" },
   { org: "actionhero", name: "ah-sequelize-plugin" },
-  { org: "taskrabbit", name: "elasticsearch-dump" },
+  { org: "evantahler", name: "mcpx" },
+  { org: "evantahler", name: "botholomew" },
+  { org: "evantahler", name: "macos-ts" },
+  { org: "elasticsearch-dump", name: "elasticsearch-dump" },
   { org: "taskrabbit", name: "empujar" },
   { org: "evantahler", name: "dont-be-a-jerk" },
 ];

--- a/.vitepress/theme/BlogPostFooter.vue
+++ b/.vitepress/theme/BlogPostFooter.vue
@@ -1,0 +1,259 @@
+<script setup lang="ts">
+import { useData, useRoute } from "vitepress";
+import { computed } from "vue";
+import { data as allPosts } from "../data/posts.data";
+
+const { frontmatter } = useData();
+const route = useRoute();
+
+const isPost = computed(() => route.path.startsWith("/blog/post/"));
+
+const currentTags = computed<string[]>(() => frontmatter.value.tags ?? []);
+
+const fmt = (d: string) =>
+  new Date(d).toLocaleDateString("en-us", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
+const related = computed(() => {
+  if (!isPost.value) return [];
+  const tags = new Set(currentTags.value);
+  const currentPath = route.path.replace(/\/$/, "");
+  return allPosts
+    .filter((p) => {
+      const url = p.url.replace(/\/$/, "").replace(/\.html$/, "");
+      return url !== currentPath;
+    })
+    .map((p) => {
+      const overlap = (p.meta.tags ?? []).filter((t) => tags.has(t)).length;
+      return { post: p, overlap };
+    })
+    .filter((x) => x.overlap > 0)
+    .sort((a, b) => {
+      if (b.overlap !== a.overlap) return b.overlap - a.overlap;
+      return (
+        new Date(b.post.meta.date).valueOf() -
+        new Date(a.post.meta.date).valueOf()
+      );
+    })
+    .slice(0, 3)
+    .map((x) => x.post);
+});
+</script>
+
+<template>
+  <footer v-if="isPost" class="post-footer">
+    <section class="byline">
+      <img
+        src="/images/bitmoji/4.png"
+        alt="Evan Tahler"
+        class="byline-avatar"
+      />
+      <div class="byline-body">
+        <p class="byline-name">Written by <strong>Evan Tahler</strong></p>
+        <p class="byline-bio">
+          Head of Engineering at
+          <a href="https://www.arcade.dev">Arcade.dev</a>, creator of
+          <a href="https://www.actionherojs.com">Actionhero</a> and
+          <a href="https://www.keryxjs.com">Keryx</a>.
+          <a href="/about">More about me →</a>
+        </p>
+      </div>
+    </section>
+
+    <section v-if="related.length > 0" class="related">
+      <h2>Keep reading</h2>
+      <ul class="related-list">
+        <li v-for="p in related" :key="p.slug">
+          <a :href="p.url" class="related-link">
+            <img
+              v-if="p.meta.image"
+              :src="p.meta.image"
+              :alt="p.meta.title"
+              class="related-thumb"
+              loading="lazy"
+            />
+            <span v-else class="related-thumb related-thumb-placeholder" aria-hidden="true"></span>
+            <span class="related-text">
+              <span class="related-date">{{ fmt(p.meta.date) }}</span>
+              <span class="related-title">{{ p.meta.title }}</span>
+            </span>
+          </a>
+        </li>
+      </ul>
+    </section>
+
+    <section class="subscribe">
+      <div class="subscribe-card">
+        <div class="subscribe-icon" aria-hidden="true">📡</div>
+        <div class="subscribe-body">
+          <h2>Liked this?</h2>
+          <p>
+            Subscribe via
+            <a href="/feed.xml"><code>/feed.xml</code></a> in your reader of
+            choice. If you happen to be an LLM, grab the whole site at
+            <a href="/llms-full.txt"><code>/llms-full.txt</code></a>. New post
+            announcements show up on
+            <a href="https://twitter.com/evantahler">Twitter</a> and
+            <a href="https://mastodon.social/@evantahler" rel="me">Mastodon</a>.
+          </p>
+        </div>
+      </div>
+    </section>
+  </footer>
+</template>
+
+<style scoped>
+.post-footer {
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--vp-c-divider);
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.byline {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.byline-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--vp-c-bg-soft);
+  flex: 0 0 auto;
+}
+.byline-body {
+  min-width: 0;
+}
+.byline-name {
+  margin: 0 0 0.2rem;
+  font-size: 0.95rem;
+  color: var(--vp-c-text-2);
+}
+.byline-bio {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--vp-c-text-2);
+}
+.byline-bio a {
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+}
+.byline-bio a:hover {
+  text-decoration: underline;
+}
+
+.related h2,
+.subscribe-body h2 {
+  margin: 0 0 0.75rem;
+  padding-top: 0;
+  border-top: none;
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.related h2 {
+  color: var(--vp-c-text-1);
+}
+.subscribe-body h2 {
+  color: var(--vp-c-brand-1);
+}
+
+.related-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.related-list li + li {
+  margin-top: 0.25rem;
+}
+.related-link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem;
+  border-radius: 8px;
+  color: inherit;
+  text-decoration: none;
+  transition: background 0.2s;
+}
+.related-link:hover {
+  background: var(--vp-c-bg-soft);
+  text-decoration: none;
+}
+.related-thumb {
+  flex: 0 0 auto;
+  width: 64px;
+  height: 64px;
+  object-fit: cover;
+  border-radius: 6px;
+  background: var(--vp-c-bg-soft);
+}
+.related-thumb-placeholder {
+  border: 1px dashed var(--vp-c-divider);
+}
+.related-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 0.15rem;
+}
+.related-date {
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--vp-c-text-3);
+}
+.related-title {
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--vp-c-text-1);
+}
+.related-link:hover .related-title {
+  color: var(--vp-c-brand-1);
+}
+
+.subscribe-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 12px;
+  background: rgba(234, 88, 12, 0.06);
+  border: 1px solid rgba(234, 88, 12, 0.35);
+}
+:global(.dark) .subscribe-card {
+  background: rgba(251, 146, 60, 0.06);
+  border-color: rgba(251, 146, 60, 0.35);
+}
+.subscribe-icon {
+  font-size: 1.75rem;
+  line-height: 1;
+}
+.subscribe-body p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: var(--vp-c-text-2);
+}
+.subscribe-body a {
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+}
+.subscribe-body a:hover {
+  text-decoration: underline;
+}
+.subscribe-body code {
+  font-size: 0.95em;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--vp-c-default-soft);
+}
+</style>

--- a/.vitepress/theme/RepoCard.vue
+++ b/.vitepress/theme/RepoCard.vue
@@ -30,6 +30,19 @@ const repo = computed(() => repos.find((r) => r.full_name === props.name));
       </p>
     </div>
   </div>
+  <div v-else class="repo-card repo-card-fallback">
+    <div class="repo-body">
+      <p>
+        <a :href="`https://github.com/${name}`" target="_blank" rel="noopener">{{
+          name
+        }}</a>
+        — view on GitHub.
+      </p>
+      <p class="repo-stats">
+        Live repo data couldn't be fetched at build time.
+      </p>
+    </div>
+  </div>
 </template>
 
 <style scoped>

--- a/.vitepress/theme/SiteFooter.vue
+++ b/.vitepress/theme/SiteFooter.vue
@@ -1,0 +1,209 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { data as allPosts } from "../data/posts.data";
+
+const recent = computed(() => allPosts.slice(0, 4));
+
+const fmt = (d: string) =>
+  new Date(d).toLocaleDateString("en-us", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
+const year = new Date().getFullYear();
+</script>
+
+<template>
+  <footer class="site-footer">
+    <div class="site-footer-inner">
+      <div class="site-footer-grid">
+        <section class="site-footer-col">
+          <h3>Recent posts</h3>
+          <ul>
+            <li v-for="p in recent" :key="p.slug">
+              <a :href="p.url">{{ p.meta.title }}</a>
+              <span class="site-footer-date">{{ fmt(p.meta.date) }}</span>
+            </li>
+          </ul>
+          <p class="site-footer-allposts">
+            <a href="/blog">All posts →</a>
+          </p>
+        </section>
+
+        <section class="site-footer-col">
+          <h3>Subscribe</h3>
+          <p>
+            New posts go out via
+            <a href="/feed.xml"><code>/feed.xml</code></a>
+            (RSS, drop into Feedly, NetNewsWire, etc.).
+          </p>
+          <p>
+            Reading with an LLM? Help yourself to
+            <a href="/llms.txt"><code>/llms.txt</code></a> and
+            <a href="/llms-full.txt"><code>/llms-full.txt</code></a>.
+          </p>
+        </section>
+
+        <section class="site-footer-col">
+          <h3>Elsewhere</h3>
+          <ul class="site-footer-socials">
+            <li>
+              <a href="https://twitter.com/evantahler" rel="noopener" target="_blank">
+                Twitter / X (@evantahler)
+              </a>
+            </li>
+            <li>
+              <a href="https://github.com/evantahler" rel="noopener" target="_blank">
+                GitHub (@evantahler)
+              </a>
+            </li>
+            <li>
+              <a href="https://linkedin.com/in/evantahler" rel="noopener" target="_blank">
+                LinkedIn
+              </a>
+            </li>
+            <li>
+              <a href="https://mastodon.social/@evantahler" rel="me noopener" target="_blank">
+                Mastodon
+              </a>
+            </li>
+          </ul>
+        </section>
+      </div>
+
+      <div class="site-footer-bottom">
+        <img src="/images/dog.png" alt="" class="footer-dog" aria-hidden="true" />
+        <p class="site-footer-meta">
+          <a href="https://github.com/evantahler/www.evantahler.com" target="_blank" rel="noopener">source for this site</a>
+          · Copyright © {{ year }} Evan Tahler
+        </p>
+      </div>
+    </div>
+  </footer>
+</template>
+
+<style scoped>
+.site-footer {
+  position: relative;
+  z-index: var(--vp-z-index-footer, 30);
+  border-top: 1px solid var(--vp-c-gutter);
+  background: var(--vp-c-bg);
+  padding: 2.5rem 1.5rem 2rem;
+}
+
+.site-footer-inner {
+  max-width: var(--vp-layout-max-width, 1440px);
+  margin: 0 auto;
+}
+
+.site-footer-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 2.5rem;
+  margin-bottom: 2.5rem;
+}
+
+@media (max-width: 720px) {
+  .site-footer-grid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.75rem;
+  }
+}
+
+.site-footer-col h3 {
+  margin: 0 0 0.85rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--vp-c-text-3);
+}
+
+.site-footer-col p {
+  margin: 0 0 0.6rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--vp-c-text-2);
+}
+
+.site-footer-col ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.5rem;
+}
+
+.site-footer-col li {
+  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.site-footer-col a {
+  color: var(--vp-c-text-1);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.site-footer-col a:hover {
+  color: var(--vp-c-brand-1);
+  text-decoration: underline;
+}
+
+.site-footer-col code {
+  font-size: 0.95em;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--vp-c-default-soft);
+}
+
+.site-footer-date {
+  font-size: 0.75rem;
+  color: var(--vp-c-text-3);
+}
+
+.site-footer-allposts {
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.site-footer-allposts a {
+  color: var(--vp-c-brand-1);
+}
+
+.site-footer-socials li {
+  flex-direction: row;
+}
+
+.site-footer-bottom {
+  text-align: center;
+  border-top: 1px solid var(--vp-c-divider);
+  padding-top: 1.5rem;
+}
+
+.footer-dog {
+  display: inline-block;
+  width: 75px;
+  height: auto;
+  margin-bottom: 0.5rem;
+}
+
+.site-footer-meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--vp-c-text-3);
+}
+
+.site-footer-meta a {
+  color: var(--vp-c-text-2);
+  text-decoration: none;
+}
+
+.site-footer-meta a:hover {
+  color: var(--vp-c-brand-1);
+  text-decoration: underline;
+}
+</style>

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -1,7 +1,9 @@
 import type { Theme } from "vitepress";
 import DefaultTheme from "vitepress/theme";
 import { h } from "vue";
+import BlogPostFooter from "./BlogPostFooter.vue";
 import BlogPostHeader from "./BlogPostHeader.vue";
+import SiteFooter from "./SiteFooter.vue";
 import "./style.css";
 
 const theme: Theme = {
@@ -9,6 +11,8 @@ const theme: Theme = {
   Layout() {
     return h(DefaultTheme.Layout, null, {
       "doc-before": () => h(BlogPostHeader),
+      "doc-after": () => h(BlogPostFooter),
+      "layout-bottom": () => h(SiteFooter),
     });
   },
   enhanceApp({ router }) {

--- a/about.md
+++ b/about.md
@@ -1,19 +1,44 @@
 ---
 title: "About Evan Tahler"
-description: About Evan Tahler — Head of Engineering at Arcade.dev, formerly Airbyte (via Grouparoo acquisition), Disney, TaskRabbit, ModCloth, Airbus.
+description: "About Evan Tahler. Head of Engineering at Arcade.dev, formerly Airbyte (via Grouparoo acquisition), Disney, TaskRabbit, ModCloth, Airbus. Creator of Actionhero and Keryx."
 ---
 
 # About
 
-![evan](/images/resume-4.png)
+![Evan Tahler](/images/resume-4.png)
 
-Evan Tahler is the Head of Engineering at [Arcade.dev](https://www.arcade.dev), building the foundation for secure and scalable agentic tools.
+Hi! I'm Evan. I've been building software professionally since 2009. My expertise sits at the intersection of two things: building the technical side of digital products, and growing the engineering teams required to do so. Most of my work has been on developer-facing infrastructure: open-source frameworks, data pipelines, and now agentic tools. I write about what I'm working on at [/blog](/blog).
 
-Prior to Arcade, Evan was the Director of Engineering of Sync Foundations at Airbyte, where he built and led the teams that focused on high-volume data movement and AI-pipelines. Evan was the CTO and co-founder of Grouparoo, the open-source reverse-ETL company, which was acquired by Airbyte.
+Currently **Head of Engineering** at [Arcade.dev](https://www.arcade.dev). Previously Director of Engineering at [Airbyte](https://airbyte.com), CTO and co-founder of [Grouparoo](https://www.grouparoo.com).
 
-Evan's expertise lies in building the technical side of digital products, and growing the teams required to do so. He's helped companies like [Airbyte](https://airbyte.com), [Disney](https://www.disney.com), [TaskRabbit](https://www.taskrabbit.com), [ModCloth](https://www.modcloth.com), and [Airbus](https://www.airbus.com) launch new global digital initiatives, and has co-founded 3 startups. He is named on multiple patents focusing on authentication and digital entertainment. Evan is an open-source innovator, and frequent speaker at software development conferences focusing on AI, Product Management, Data Engineering, Node.JS, Typescript and DevOps.
+## What I'm working on now
 
-Evan holds a Masters in Entertainment Technology and BS in Mechanical Engineering from [Carnegie Mellon University](https://www.cmu.edu/homepage/creativity/2014/fall/the-greater-good.shtml).
+At [Arcade.dev](https://www.arcade.dev) I lead the engineering team building the runtime for secure, scalable agentic tools: the layer that lets AI models actually take real-world actions on a user's behalf without the whole thing collapsing into a security incident.
+
+In my spare time I'm building [Keryx](https://www.keryxjs.com), a fullstack TypeScript framework where one Action class becomes an HTTP API, an MCP server, a WebSocket handler, a CLI tool, and a background task runner. I'm also building [macos-ts](https://github.com/evantahler/macos-ts), which gives you typed APIs over your iCloud data.
+
+## What I've built
+
+I'm probably best known in open source for **[Actionhero](https://www.actionherojs.com)** and **[node-resque](https://github.com/actionhero/node-resque)**: the realtime multi-transport Node.js framework and the Redis-backed background-job system I've maintained since 2012. Other projects:
+
+- **[Keryx](https://www.keryxjs.com)**: fullstack TypeScript framework for APIs and MCP servers (current focus)
+- **[elasticsearch-dump](https://github.com/elasticsearch-dump/elasticsearch-dump)**: import/export tools for Elasticsearch and OpenSearch (~7.9k stars, started at TaskRabbit)
+- **[Grouparoo](https://github.com/grouparoo/grouparoo)**: open-source reverse-ETL, acquired by Airbyte in 2021
+
+The full list lives at [/open-source](/open-source). If any of it's useful to you, [GitHub Sponsors](https://github.com/users/evantahler/sponsorship) keeps the lights on.
+
+## How I got here
+
+The through-line across every role has been the same: developer tools, data, and middleware. The infrastructure that sits between an application and what makes it work, and the engineering teams that ship it.
+
+- **[Arcade.dev](https://www.arcade.dev)**: Head of Engineering. Leading the team building the runtime for secure, scalable agentic tools.
+- **[Airbyte](https://airbyte.com)**: Director of Engineering, Sync Foundations. Built and led the teams focused on high-volume data movement and AI pipelines.
+- **[Grouparoo](https://www.grouparoo.com)**: CTO and co-founder of the open-source reverse-ETL company. Built the engineering team and the platform; acquired by Airbyte in 2021.
+- **Earlier**: engineering and product roles helping [Disney](https://www.disney.com), [TaskRabbit](https://www.taskrabbit.com), [ModCloth](https://www.modcloth.com), and [Airbus](https://www.airbus.com) launch new global digital initiatives. Co-founded three successful startups along the way; named on multiple patents around authentication and digital entertainment.
+
+I'm also a frequent speaker at software development conferences on AI, product management, data engineering, Node.js, TypeScript, and DevOps. The full list of talks is at [/speaking](/speaking).
+
+I went to [Carnegie Mellon](https://www.cmu.edu/homepage/creativity/2014/fall/the-greater-good.shtml) for both undergrad (BS, Mechanical Engineering) and grad school (MS, Entertainment Technology), which is a less surprising combination than it sounds.
 
 ## Companies
 
@@ -27,6 +52,13 @@ Evan holds a Masters in Entertainment Technology and BS in Mechanical Engineerin
   <a href="https://www.modcloth.com"><img src="/images/logos/modcloth.jpg" alt="modcloth" /></a>
   <a href="https://www.disney.com"><img src="/images/logos/disney.png" alt="disney" /></a>
 </p>
+
+## Stay in touch
+
+- Read what I'm thinking about → [/blog](/blog)
+- Talks I've given → [/speaking](/speaking)
+- Open source projects → [/open-source](/open-source)
+- Email, calendar, and socials → [/contact](/contact)
 
 <style scoped>
 .company-logos {

--- a/blog/post/2025-07-23-designing-sql-tools-for-ai-agents.md
+++ b/blog/post/2025-07-23-designing-sql-tools-for-ai-agents.md
@@ -11,7 +11,7 @@ tags:
   - engineering
   - ai
 canonical: 'https://blog.arcade.dev/sql-tools-ai-agents-security'
-featured: false
+featured: true
 ---
 
 ![Additional workflow example showing SQL tool implementation](/images/posts/2025-07-23-designing-sql-tools-for-ai-agents/additional-workflow.png)

--- a/blog/post/2026-05-01-software-for-humans-and-agents.md
+++ b/blog/post/2026-05-01-software-for-humans-and-agents.md
@@ -13,7 +13,7 @@ tags:
   - typescript
   - ai
   - open-source
-featured: false
+featured: true
 ---
 
 ![Building software for humans and agents](/images/posts/2026-05-01-software-for-humans-and-agents/image.png)
@@ -128,5 +128,3 @@ The shift is the audience. "The consumer of your software" used to mean a person
 The libraries that ship that way will be the libraries that get used. The frameworks that ship that way will be the frameworks that build them. And honestly — having now done both — the work is mostly the work I should have been doing for human readers all along. The agents just don't let me cheat.
 
 Onward.
-
-_Evan Tahler is Head of Engineering at [Arcade](https://arcade.dev). He's the creator of [Actionhero](https://github.com/actionhero/actionhero), [Keryx](https://www.keryxjs.com/), [macos-ts](https://github.com/evantahler/macos-ts), and [mcpx](https://github.com/evantahler/mcpx)._

--- a/open-source.md
+++ b/open-source.md
@@ -1,6 +1,6 @@
 ---
 title: "Evan Tahler: Open Source Software"
-description: Evan Tahler's contributions to open source software including Actionhero, Grouparoo, Airbyte, and node-resque.
+description: "Evan Tahler's open-source work: Actionhero, Keryx, Grouparoo, Airbyte, node-resque, and more."
 ---
 
 <script setup>
@@ -11,44 +11,113 @@ import RepoCard from "./.vitepress/theme/RepoCard.vue";
 
 ![open source](/images/open-source-3.png)
 
-I contribute to a number of open source projects because I believe it is a great way to give back to the programming community in both a professional and personal capacity — and a great way to learn about new technologies and tools.
+I contribute to open source because it's the best way I've found to learn new tech, share what I've figured out, and give back to a community that's given me a lot. Some of these projects I started; some I lead; some I'm just an active contributor to. The list below is in rough order of how much of my attention each one gets right now.
 
-You can [sponsor my open source work via GitHub Sponsorships](https://github.com/users/evantahler/sponsorship).
+If any of this is useful to you, you can [sponsor my open-source work via GitHub Sponsors](https://github.com/users/evantahler/sponsorship).
 
 ## Featured Projects
 
-### ArcadeAI/arcade-mcp
+The flagships: projects I started, BDFL, and where most of my open-source energy lives.
 
-<RepoCard name="ArcadeAI/arcade-mcp" />
+### [actionhero/keryx](https://github.com/actionhero/keryx)
 
-### airbytehq/airbyte
+<RepoCard name="actionhero/keryx" />
 
-<RepoCard name="airbytehq/airbyte" />
+A fullstack TypeScript framework for APIs and MCP servers. Write one Action class. Get HTTP, WebSockets, an MCP server, a CLI, and a background task runner, all from the same code. The thinking behind it is in [Announcing Keryx](/blog/post/2026-03-13-announcing-keryx). This is where my evenings go right now.
 
-### grouparoo/grouparoo
+<p class="flagship-links">
+  <a href="https://www.keryxjs.com">keryxjs.com</a> ·
+  <a href="/blog/post/2026-03-13-announcing-keryx">Announcement post</a>
+</p>
 
-<RepoCard name="grouparoo/grouparoo" />
-
-### actionhero/actionhero
+### [actionhero/actionhero](https://www.actionherojs.com)
 
 <RepoCard name="actionhero/actionhero" />
 
-### actionhero/node-resque
+The realtime multi-transport Node.js framework I started in 2012 and still maintain. Stable, well-tested, and powering production traffic at companies I've never even heard of. [Why Choose Actionhero](/blog/post/2017-02-28-why-choose-actionhero) is the long version of the pitch.
+
+### [grouparoo/grouparoo](https://github.com/grouparoo/grouparoo)
+
+<RepoCard name="grouparoo/grouparoo" />
+
+The open-source reverse-ETL company I co-founded as CTO. Acquired by Airbyte in 2021; the repo is archived but the ideas live on inside Airbyte's data sync foundation.
+
+### [elasticsearch-dump/elasticsearch-dump](https://github.com/elasticsearch-dump/elasticsearch-dump)
+
+<RepoCard name="elasticsearch-dump/elasticsearch-dump" />
+
+The import/export swiss-army-knife for Elasticsearch and OpenSearch. Started at TaskRabbit, now a community-maintained project that's racked up nearly 8k stars.
+
+## Active Maintenance
+
+Newer side projects and smaller libraries I'm actively building on.
+
+### [evantahler/mcpx](https://github.com/evantahler/mcpx)
+
+<RepoCard name="evantahler/mcpx" />
+
+A command-line interface for MCP servers. `curl` for MCP. Coding agents already know how to use the CLI; this lets them talk to MCP servers the same way. Background in [curl for MCP](/blog/post/2026-03-13-curl-for-mcp).
+
+### [evantahler/botholomew](https://www.botholomew.com)
+
+<RepoCard name="evantahler/botholomew" />
+
+A local, autonomous AI agent for knowledge work. Hand it a task queue, walk away, let it grind through the backlog.
+
+### [evantahler/macos-ts](https://github.com/evantahler/macos-ts)
+
+<RepoCard name="evantahler/macos-ts" />
+
+Typed APIs over your iCloud data: Notes, Messages, Photos, Contacts. Absorbs the SQLite weirdness so you don't have to.
+
+### [actionhero/node-resque](https://github.com/actionhero/node-resque)
 
 <RepoCard name="actionhero/node-resque" />
 
-### actionhero/ah-sequelize-plugin
+Redis-backed background jobs for Node.js. Part of the Actionhero ecosystem.
+
+### [actionhero/ah-sequelize-plugin](https://github.com/actionhero/ah-sequelize-plugin)
 
 <RepoCard name="actionhero/ah-sequelize-plugin" />
 
-### taskrabbit/elasticsearch-dump
+## Work Contributions
 
-<RepoCard name="taskrabbit/elasticsearch-dump" />
+Major projects I contribute to as part of my day job.
 
-### taskrabbit/empujar
+### [ArcadeAI/arcade-mcp](https://github.com/ArcadeAI/arcade-mcp)
+
+<RepoCard name="ArcadeAI/arcade-mcp" />
+
+### [airbytehq/airbyte](https://github.com/airbytehq/airbyte)
+
+<RepoCard name="airbytehq/airbyte" />
+
+## Earlier Projects
+
+Older projects I'm not actively developing but that still get used.
+
+### [taskrabbit/empujar](https://github.com/taskrabbit/empujar)
 
 <RepoCard name="taskrabbit/empujar" />
 
-### evantahler/dont-be-a-jerk
+### [evantahler/dont-be-a-jerk](https://github.com/evantahler/dont-be-a-jerk)
 
 <RepoCard name="evantahler/dont-be-a-jerk" />
+
+## Support this work
+
+If any of these projects has saved you an afternoon, [GitHub Sponsorships](https://github.com/users/evantahler/sponsorship) is the cleanest way to say thanks. Every sponsorship goes directly toward the time I spend maintaining the open-source side of my work: keeping issues moving, releases shipping, and docs vaguely up to date.
+
+<style scoped>
+.flagship-links {
+  font-size: 0.9rem;
+  color: var(--vp-c-text-2);
+}
+.flagship-links a {
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+}
+.flagship-links a:hover {
+  text-decoration: underline;
+}
+</style>

--- a/speaking.md
+++ b/speaking.md
@@ -7,7 +7,7 @@ description: Talks Evan Tahler has given on Node.js, Ruby, DevOps, AI, Data Engi
 
 ![speaking](/images/speaking-3.png)
 
-I've given a number of technical talks, focusing on Node.js, Ruby, AI, and DevOps.
+I've given a number of technical talks over the years on Node.js, Ruby, DevOps, data engineering, and lately AI agents and MCP. If you'd like me to speak at your event, guest on your podcast, or join a panel, [get in touch](/contact). I take a few of these a year and I'm happy to consider more.
 
 ## Featured Talks
 
@@ -135,6 +135,9 @@ This talk was inspired by a group of students learning to code in Seattle who we
 </div>
 </div>
 
+<details class="earlier-talks">
+<summary>Earlier talks (2015–2016)</summary>
+
 <div class="talk">
 <img class="talk-image" src="/images/redisconf.jpg" alt="Background Tasks in Node.js: A survey with Redis" />
 <div class="talk-body">
@@ -168,6 +171,12 @@ Node.js is great for all sorts of projects. In this demo, we will use Node.js to
 </div>
 </div>
 
+</details>
+
+## Want me to speak?
+
+If you're organizing a conference, meetup, podcast, or panel and any of the above looks relevant, I'd love to hear from you: [/contact](/contact). I'm especially interested in talks on AI agents, MCP, framework design, and the engineering-leadership side of building developer tools.
+
 <style scoped>
 .talk {
   display: grid;
@@ -185,6 +194,21 @@ Node.js is great for all sorts of projects. In this demo, we will use Node.js to
 }
 .talk-body h3 {
   margin: 0 0 0.5rem;
+}
+.earlier-talks {
+  margin: 1rem 0 2rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+}
+.earlier-talks summary {
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0.5rem 0;
+}
+.earlier-talks[open] summary {
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--vp-c-divider);
 }
 @media (max-width: 640px) {
   .talk {


### PR DESCRIPTION
## Summary

Editorial and creative pass across the static pages plus two new global components.

- **About** rewritten to lead with team-leadership positioning, switch to "runtime" wording for Arcade, strengthen career bullets, and add a speaker line.
- **Open Source** restructured into Featured / Active / Work / Earlier tiers with Keryx, mcpx, Botholomew, and macos-ts surfaced; fixed the `elasticsearch-dump` org rename so its icon loads again, and added a `RepoCard` fallback for when the GitHub API can't resolve a repo.
- **Speaking** got invite-me CTAs at the top and bottom; pre-2018 talks tucked into a `<details>` block so the page leads with current work.
- New **`BlogPostFooter`** (byline + up-to-3 related posts ranked by tag overlap + subscribe nudge) injected via the `doc-after` slot.
- New **`SiteFooter`** (recent posts / subscribe / socials columns + dog and copyright) injected via `layout-bottom`; replaces the prior `themeConfig.footer`.
- Promoted `2026-05-01` and `2025-07-23` posts to `featured: true` so the home grid surfaces current AI/agent work; dropped the now-redundant trailing author-bio line from the 2026-05-01 post.

## Test plan

- [ ] `bun run lint` clean
- [ ] `bun run build` clean
- [ ] `bun run test` (226 tests) all green
- [ ] Visit `/` — featured grid shows the 4 most recent featured posts
- [ ] Visit `/about` — leadership intro + "runtime" copy + speaker line
- [ ] Visit `/open-source` — every flagship/active card has a GitHub icon (incl. `actionhero/keryx` and `elasticsearch-dump/elasticsearch-dump`)
- [ ] Visit `/speaking` — invite-me CTAs render; older talks behind details
- [ ] Visit any blog post — BlogPostFooter renders with byline, related posts, subscribe nudge
- [ ] On every page, SiteFooter shows recent posts / subscribe / elsewhere columns and doesn't collide visually with the right-hand outline on long pages
- [ ] Tag pills, RSS, llms.txt, llms-full.txt all reachable from the footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)