### PR TITLE
Sound-human pass on the latest 2 blog posts

### DIFF
--- a/blog/post/2026-03-13-announcing-keryx.md
+++ b/blog/post/2026-03-13-announcing-keryx.md
@@ -34,7 +34,7 @@ A single Keryx Action automatically becomes:
 - A **background task** via Resque workers
 - An **MCP tool, resource, or prompt** that AI agents can discover and call
 
-Same validation. Same middleware. Same error handling. Five transports, one class.  Oh, and Actions are composabile now. 
+Same validation, same middleware, same error handling. Five transports, one class. Oh, and Actions are composable now.
 
 ## One Action, Every Transport
 
@@ -60,23 +60,23 @@ export class UserView implements Action {
 
 That's it. This class is simultaneously a `GET /user` endpoint, a WebSocket action, a `user:view` CLI command, and an MCP tool. The Zod schema drives input validation for every transport, and it auto-generates your OpenAPI documentation. An AI agent running `user:view` gets the same validation and error handling as a curl request hitting `/user` — because it's the same code path.
 
-If you've used Actionhero, this should feel familiar. If you haven't, the idea is straightforward: your business logic shouldn't care how a request arrived, and in-fact, any sophsticated application will need multiple transports. 
+If you've used Actionhero, this should feel familiar. If you haven't, the idea is straightforward: your business logic shouldn't care how a request arrived. Any sophisticated application will need multiple transports anyway.
 
 ## What You Get on Day One
 
-A scaffolded Keryx app boots with cookie sessions, OAuth 2.1, rate limiting, security headers, CORS, WebSocket origin validation, OpenTelemetry metrics, structured logging with correlation IDs, automatic Drizzle migrations, an OpenAPI 3 spec at `/api/swagger`, an MCP server, fan-out background tasks, real-time channels with presence tracking, and a CLI that registers every action as a command. None of these are plugins you bolt on later... but we also have a plugin system and a nacent colletion of plugins. 
+A scaffolded Keryx app boots with cookie sessions, OAuth 2.1, rate limiting, security headers, CORS, WebSocket origin validation, OpenTelemetry metrics, structured logging with correlation IDs, automatic Drizzle migrations, an OpenAPI 3 spec at `/api/swagger`, an MCP server, fan-out background tasks, real-time channels with presence tracking, and a CLI that registers every action as a command. None of these are plugins you bolt on later — but there's also a plugin system and a nascent collection of plugins.
 
 ## Why MCP Changes Things
 
-The first four transports — HTTP, WebSocket, CLI, tasks — those are table stakes for a full-stack framework. Actionhero had all of them (well, CLI was a stretch). The reason I built Keryx instead of continuing to evolve Actionhero is the fifth one: MCP.
+The first four transports — HTTP, WebSocket, CLI, tasks — every full-stack framework should have those. Actionhero had all of them (well, CLI was a stretch). The reason I built Keryx instead of continuing to evolve Actionhero is the fifth one: MCP.
 
 [MCP](https://modelcontextprotocol.io/) (Model Context Protocol) is how AI agents discover and use tools. It's becoming the standard interface between agents and the services they interact with. If you're already defining your actions with typed inputs, descriptions, and structured outputs… you're 90% of the way to an MCP tool. The shape of a good Action and the shape of a good MCP tool are nearly identical.
 
 Keryx makes the last 10% automatic. Every Action can be registered as an MCP tool with zero additional configuration. Your Zod schema becomes the tool's input schema. Your Action's name becomes the tool name. An AI agent can discover your API the same way a human developer reads your OpenAPI docs — except the agent gets a protocol it natively understands.
 
-That also means Keryx gives you per-session agent isolation and OAuth 2.1 with PKCE out of the box. Because when agents are calling your API, authentication and scoping aren't optional.  Note: we are talking about MCP-over HTTP (not stdio) - Keryx is for a deployed, remote, application.
+That also means Keryx gives you per-session agent isolation and OAuth 2.1 with PKCE out of the box. Because when agents are calling your API, authentication and scoping aren't optional. (To be clear: this is MCP over HTTP, not stdio. Keryx is for deployed, remote applications.)
 
-The same Action class can also become an MCP **resource** (URI-addressed, read-only context that agents fetch) or an MCP **prompt** (a named template surfaced as a slash command in clients like Claude Desktop). Keryx aims to support /all/ of MCP.
+The same Action class can also become an MCP **resource** (URI-addressed, read-only context that agents fetch) or an MCP **prompt** (a named template surfaced as a slash command in clients like Claude Desktop). Keryx aims to support *all* of MCP.
 
 ## Design Tools as Intentions, Not CRUD
 

--- a/blog/post/2026-05-01-software-for-humans-and-agents.md
+++ b/blog/post/2026-05-01-software-for-humans-and-agents.md
@@ -20,7 +20,7 @@ featured: true
 
 I've been building a few things in my spare time. A library — [macos-ts](https://github.com/evantahler/macos-ts), which gives you typed APIs over your iCloud data (Notes, Messages, Photos, Contacts) and absorbs the SQLite madness so you don't have to. And a framework — [Keryx](https://www.keryxjs.com/), the fullstack TypeScript framework for MCP and APIs: one Action class, five transports, your API is automatically an MCP server, a WebSocket handler, a CLI tool, and a background task runner.
 
-I've learned that every piece of software I write now has two audiences: a human, and an agent acting on a human's behalf. They want different things. They forgive different things. They fail differently. And building for both at once changes how you write the code.
+I've learned that every piece of software I write now has two audiences: a human, and an agent acting on a human's behalf. They want different things from the same call, and they fail in completely different ways when they don't get it. Building for both at once changes how you write the code.
 
 That sounds like a fluffy thought-leader sentence, so let me make it concrete.
 
@@ -34,7 +34,7 @@ That's not enough anymore. Your users are running agents now, and those agents w
 
 Half the internet is calling MCP "USB for agents." It's a goofy phrase, but it's basically right. MCP is the universal bus — and the underrated part is that it transcends the language your library was written in. A Python agent can call a TypeScript library. A Rust agent can call a Ruby library. The protocol is the contract; whatever your library is written in is now an implementation detail.
 
-The good news: the rules for shipping a good MCP server are the same rules for shipping a good library. Hide complexity. Return errors that explain what to do next. Write documentation that actually documents.
+The good news: the rules for shipping a good MCP server are the same rules for shipping a good library. Hide complexity, and return errors that explain what to do next.
 
 The bad news: most existing libraries fail those rules in ways that humans politely tolerate and agents don't.
 
@@ -123,8 +123,8 @@ A few things this reframing buys you, beyond the obvious "write less code":
 
 It's tempting to read all of this as "ship MCP," and stop there. That's not the point.
 
-The shift is the audience. "The consumer of your software" used to mean a person at a keyboard, or another piece of code a person wrote. Now it includes an agent acting on someone's behalf — sometimes the same person, sometimes not. That audience needs the same care you'd give a human reader of your README. Clear names. Useful errors. Docs that don't make them guess.
+The shift is the audience. "The consumer of your software" used to mean a person at a keyboard, or another piece of code a person wrote. Now it includes an agent acting on someone's behalf — sometimes the same person, sometimes not. That audience needs the same care you'd give a human reader of your README. Clear names, useful errors, and docs that don't make them guess.
 
-The libraries that ship that way will be the libraries that get used. The frameworks that ship that way will be the frameworks that build them. And honestly — having now done both — the work is mostly the work I should have been doing for human readers all along. The agents just don't let me cheat.
+The libraries and frameworks that ship that way are the ones that get used. The rest get politely worked around. And honestly — having now done both — the work is mostly the work I should have been doing for human readers all along. The agents just don't let me cheat.
 
 Onward.


### PR DESCRIPTION
## Summary

Audited `2026-05-01-software-for-humans-and-agents.md` and `2026-03-13-announcing-keryx.md` against the new `/sound-human` skill: broke up three rule-of-three triplets, softened a symmetrical closer, fixed several typos (`composabile`, `sophsticated`, `nacent colletion`), replaced "table stakes", and corrected `/all/` → `*all*` italics.

## Test plan

- [x] `bun run lint`
- [x] `bun run test:unit` (175/175)
- [ ] Spot-check rendered posts at `/blog/post/2026-05-01-software-for-humans-and-agents` and `/blog/post/2026-03-13-announcing-keryx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)