### PR TITLE
Add 'arcade' tag to Arcade-related blog posts

### DIFF
--- a/__tests__/content/tags-allowlist.test.ts
+++ b/__tests__/content/tags-allowlist.test.ts
@@ -22,6 +22,7 @@ const ALLOWED_TAGS = new Set([
   "frontend",
   "career",
   // companies & projects
+  "arcade",
   "actionhero",
   "grouparoo",
   "taskrabbit",

--- a/blog/post/2025-07-23-designing-sql-tools-for-ai-agents.md
+++ b/blog/post/2025-07-23-designing-sql-tools-for-ai-agents.md
@@ -10,6 +10,7 @@ image: >-
 tags:
   - engineering
   - ai
+  - arcade
 canonical: 'https://blog.arcade.dev/sql-tools-ai-agents-security'
 featured: true
 ---

--- a/blog/post/2026-03-13-curl-for-mcp.md
+++ b/blog/post/2026-03-13-curl-for-mcp.md
@@ -10,6 +10,7 @@ image: /images/posts/2026-03-13-curl-for-mcp/image1.png
 tags:
   - engineering
   - ai
+  - arcade
 canonical: 'https://blog.arcade.dev/curl-for-mcp'
 featured: true
 ---

--- a/blog/post/2026-05-01-software-for-humans-and-agents.md
+++ b/blog/post/2026-05-01-software-for-humans-and-agents.md
@@ -13,6 +13,7 @@ tags:
   - typescript
   - ai
   - open-source
+  - arcade
 featured: true
 ---
 


### PR DESCRIPTION
## Summary
Adds an `arcade` tag to the three blog posts that reference Arcade:
- `curl for MCP`
- `Designing SQL Tools for AI Agents`
- `Building Software for Humans and Agents`

A case-insensitive grep of `blog/post/` for "arcade" returns exactly these three posts. Also adds `arcade` to the tag allowlist in `__tests__/content/tags-allowlist.test.ts` (under "companies & projects"), since that test enforces a fixed set.

A new `/blog/tag/arcade` page is auto-generated by `blog/tag/[tag].paths.ts`.

## Verification
- `bun run lint` — passes
- `bun run test:unit` — 175 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)